### PR TITLE
fix: Do not used cached UDR URI, because validity period is ignored

### DIFF
--- a/producer/ue_context_management.go
+++ b/producer/ue_context_management.go
@@ -40,9 +40,7 @@ func getUdrURI(id string) string {
 	if strings.Contains(id, "imsi") || strings.Contains(id, "nai") { // supi
 		ue, ok := udm_context.UDM_Self().UdmUeFindBySupi(id)
 		if ok {
-			if ue.UdrUri == "" {
-				ue.UdrUri = consumer.SendNFIntancesUDR(id, consumer.NFDiscoveryToUDRParamSupi)
-			}
+			ue.UdrUri = consumer.SendNFIntancesUDR(id, consumer.NFDiscoveryToUDRParamSupi)
 			return ue.UdrUri
 		} else {
 			ue = udm_context.UDM_Self().NewUdmUe(id)
@@ -54,15 +52,11 @@ func getUdrURI(id string) string {
 		udm_context.UDM_Self().UdmUePool.Range(func(key, value interface{}) bool {
 			ue := value.(*udm_context.UdmUeContext)
 			if ue.Amf3GppAccessRegistration != nil && ue.Amf3GppAccessRegistration.Pei == id {
-				if ue.UdrUri == "" {
-					ue.UdrUri = consumer.SendNFIntancesUDR(ue.Supi, consumer.NFDiscoveryToUDRParamSupi)
-				}
+				ue.UdrUri = consumer.SendNFIntancesUDR(ue.Supi, consumer.NFDiscoveryToUDRParamSupi)
 				udrURI = ue.UdrUri
 				return false
 			} else if ue.AmfNon3GppAccessRegistration != nil && ue.AmfNon3GppAccessRegistration.Pei == id {
-				if ue.UdrUri == "" {
-					ue.UdrUri = consumer.SendNFIntancesUDR(ue.Supi, consumer.NFDiscoveryToUDRParamSupi)
-				}
+				ue.UdrUri = consumer.SendNFIntancesUDR(ue.Supi, consumer.NFDiscoveryToUDRParamSupi)
 				udrURI = ue.UdrUri
 				return false
 			}


### PR DESCRIPTION
The UDR URI is currently cached in the UE context, in the UDM context. However, the validity period returned by the NRF is completely ignored, causing problems when the UDR changes IP for any reason.

This fix simply asks the NRF for the UDR URI every time. A more complete fix will need to be considered in the future, but will be a lot more involved, as it will require storing an expiry time along with the URI, allowing the cache to be invalidated.