### PR TITLE
chore: Adds gofmt and unused lint checks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -218,11 +218,11 @@ linters-settings:
 
 linters:
   enable:
-    # - gofmt
+    - gofmt
     - govet
     - errcheck
     # - staticcheck
-    # - unused
+    - unused
     # - gosimple
     # - ineffassign
     - typecheck

--- a/service/init.go
+++ b/service/init.go
@@ -49,8 +49,7 @@ func init() {
 type (
 	// Config information.
 	Config struct {
-		udmcfg         string
-		heartBeatTimer string
+		udmcfg string
 	}
 )
 


### PR DESCRIPTION
# Description

This PR enables the `go fmt` lint check which required no other change as well as the  `unused` lint checks which required a small change.