### PR TITLE
chore: Move http_wrapper dependency to util project

### DIFF
--- a/eventexposure/api_create_ee_subscription.go
+++ b/eventexposure/api_create_ee_subscription.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/udm/logger"
@@ -56,7 +56,7 @@ func HTTPCreateEeSubscription(c *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(c.Request, eeSubscriptionReq)
+	req := httpwrapper.NewRequest(c.Request, eeSubscriptionReq)
 	req.Params["ueIdentity"] = c.Params.ByName("ueIdentity")
 
 	rsp := producer.HandleCreateEeSubscription(req)

--- a/eventexposure/api_delete_ee_subscription.go
+++ b/eventexposure/api_delete_ee_subscription.go
@@ -17,13 +17,13 @@ package eventexposure
 import (
 	"github.com/gin-gonic/gin"
 
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/udm/producer"
 )
 
 // DeleteEeSubscription - Unsubscribe
 func HTTPDeleteEeSubscription(c *gin.Context) {
-	req := http_wrapper.NewRequest(c.Request, nil)
+	req := httpwrapper.NewRequest(c.Request, nil)
 	req.Params["ueIdentity"] = c.Params.ByName("ueIdentity")
 	req.Params["subscriptionID"] = c.Params.ByName("subscriptionId")
 

--- a/eventexposure/api_update_ee_subscription.go
+++ b/eventexposure/api_update_ee_subscription.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/udm/logger"
@@ -56,7 +56,7 @@ func HTTPUpdateEeSubscription(c *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(c.Request, patchList)
+	req := httpwrapper.NewRequest(c.Request, patchList)
 	req.Params["ueIdentity"] = c.Params.ByName("ueIdentity")
 	req.Params["subscriptionID"] = c.Params.ByName("subscriptionId")
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/omec-project/config5g v1.2.0
 	github.com/omec-project/http2_util v1.1.0
-	github.com/omec-project/http_wrapper v1.1.0
 	github.com/omec-project/logger_util v1.1.0
 	github.com/omec-project/milenage v1.1.0
 	github.com/omec-project/openapi v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -192,8 +192,6 @@ github.com/omec-project/config5g v1.2.0 h1:fyIg+1LZ9jn8DTkVUbD4jyxA4FgMICdIBwZVn
 github.com/omec-project/config5g v1.2.0/go.mod h1:AWFzCbbgCBx/iJwt+zWbpDGLHRpFzg24OYHqIkdcMVA=
 github.com/omec-project/http2_util v1.1.0 h1:8H2NME/V8iONth8TlyK/3w4pguAzaeUnEv9pmeAocwQ=
 github.com/omec-project/http2_util v1.1.0/go.mod h1:QwoZRaUyhEp/kTEqXvf0gCYtfQrNHBdkVw939vsMjZY=
-github.com/omec-project/http_wrapper v1.1.0 h1:2hD8RUaR/VVg3tUUfuxsuo1/JNpZLiAE8IvATGqDME4=
-github.com/omec-project/http_wrapper v1.1.0/go.mod h1:mc045fjVVJ0/q0g4QG4nuSC0N1BIqGR/ZoK76XgifVU=
 github.com/omec-project/logger_conf v1.0.100-dev/go.mod h1:Upj0MgzSpB/Ifw+3WsBaYbqWuF4SyyUeKqW7/HhL8Aw=
 github.com/omec-project/logger_conf v1.1.0 h1:C0/HbsSOWV8D3/lm7Iqe1nUL9ltVtVO4MDC9ZxIo/xc=
 github.com/omec-project/logger_conf v1.1.0/go.mod h1:2+SOX9OFbPZ+UNv8k+tvPnaWHo4CuX5G/x12dz5sWUE=

--- a/httpcallback/data_change_notification_to_nf.go
+++ b/httpcallback/data_change_notification_to_nf.go
@@ -9,11 +9,11 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/omec-project/http_wrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/udm/logger"
 	"github.com/omec-project/udm/producer"
+	"github.com/omec-project/util/httpwrapper"
 )
 
 func HTTPDataChangeNotificationToNF(c *gin.Context) {
@@ -46,7 +46,7 @@ func HTTPDataChangeNotificationToNF(c *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(c.Request, dataChangeNotify)
+	req := httpwrapper.NewRequest(c.Request, dataChangeNotify)
 	req.Params["supi"] = c.Params.ByName("supi")
 
 	rsp := producer.HandleDataChangeNotificationToNFRequest(req)

--- a/parameterprovision/api_subscription_data_update.go
+++ b/parameterprovision/api_subscription_data_update.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/udm/logger"
@@ -58,7 +58,7 @@ func HTTPUpdate(c *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(c.Request, ppDataReq)
+	req := httpwrapper.NewRequest(c.Request, ppDataReq)
 	req.Params["gspi"] = c.Params.ByName("gpsi")
 
 	rsp := producer.HandleUpdateRequest(req)

--- a/producer/callback.go
+++ b/producer/callback.go
@@ -8,14 +8,14 @@ package producer
 import (
 	"net/http"
 
-	"github.com/omec-project/http_wrapper"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/udm/logger"
 	"github.com/omec-project/udm/producer/callback"
+	"github.com/omec-project/util/httpwrapper"
 )
 
 // HandleDataChangeNotificationToNFRequest ... Send Data Change Notification
-func HandleDataChangeNotificationToNFRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleDataChangeNotificationToNFRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	// step 1: log
 	logger.CallbackLog.Infof("Handle DataChangeNotificationToNF")
 
@@ -27,8 +27,8 @@ func HandleDataChangeNotificationToNFRequest(request *http_wrapper.Request) *htt
 
 	// step 4: process the return value from step 3
 	if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	} else {
-		return http_wrapper.NewResponse(http.StatusNoContent, nil, nil)
+		return httpwrapper.NewResponse(http.StatusNoContent, nil, nil)
 	}
 }

--- a/producer/event_exposure.go
+++ b/producer/event_exposure.go
@@ -10,13 +10,13 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/omec-project/http_wrapper"
 	"github.com/omec-project/openapi/models"
 	udm_context "github.com/omec-project/udm/context"
 	"github.com/omec-project/udm/logger"
+	"github.com/omec-project/util/httpwrapper"
 )
 
-func HandleCreateEeSubscription(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleCreateEeSubscription(request *httpwrapper.Request) *httpwrapper.Response {
 	logger.EeLog.Infoln("Handle Create EE Subscription")
 
 	eesubscription := request.Body.(models.EeSubscription)
@@ -24,15 +24,15 @@ func HandleCreateEeSubscription(request *http_wrapper.Request) *http_wrapper.Res
 
 	createdEESubscription, problemDetails := CreateEeSubscriptionProcedure(ueIdentity, eesubscription)
 	if createdEESubscription != nil {
-		return http_wrapper.NewResponse(http.StatusCreated, nil, createdEESubscription)
+		return httpwrapper.NewResponse(http.StatusCreated, nil, createdEESubscription)
 	} else if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	} else {
 		problemDetails = &models.ProblemDetails{
 			Status: http.StatusInternalServerError,
 			Cause:  "UNSPECIFIED_NF_FAILURE",
 		}
-		return http_wrapper.NewResponse(http.StatusInternalServerError, nil, problemDetails)
+		return httpwrapper.NewResponse(http.StatusInternalServerError, nil, problemDetails)
 	}
 }
 
@@ -130,12 +130,12 @@ func CreateEeSubscriptionProcedure(ueIdentity string,
 	}
 }
 
-func HandleDeleteEeSubscription(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleDeleteEeSubscription(request *httpwrapper.Request) *httpwrapper.Response {
 	ueIdentity := request.Params["ueIdentity"]
 	subscriptionID := request.Params["subscriptionID"]
 
 	DeleteEeSubscriptionProcedure(ueIdentity, subscriptionID)
-	return http_wrapper.NewResponse(http.StatusNoContent, nil, nil)
+	return httpwrapper.NewResponse(http.StatusNoContent, nil, nil)
 }
 
 // TODO: complete this procedure based on TS 29503 5.5
@@ -171,7 +171,7 @@ func DeleteEeSubscriptionProcedure(ueIdentity string, subscriptionID string) {
 	}
 }
 
-func HandleUpdateEeSubscription(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleUpdateEeSubscription(request *httpwrapper.Request) *httpwrapper.Response {
 	logger.EeLog.Infoln("Handle Update EE subscription")
 	logger.EeLog.Warnln("Update EE Subscription is not implemented")
 
@@ -181,9 +181,9 @@ func HandleUpdateEeSubscription(request *http_wrapper.Request) *http_wrapper.Res
 
 	problemDetails := UpdateEeSubscriptionProcedure(ueIdentity, subscriptionID, patchList)
 	if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	} else {
-		return http_wrapper.NewResponse(http.StatusNoContent, nil, nil)
+		return httpwrapper.NewResponse(http.StatusNoContent, nil, nil)
 	}
 }
 

--- a/producer/generate_auth_data.go
+++ b/producer/generate_auth_data.go
@@ -16,7 +16,6 @@ import (
 	"strings"
 
 	"github.com/antihax/optional"
-	"github.com/omec-project/http_wrapper"
 	"github.com/omec-project/milenage"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/Nudr_DataRepository"
@@ -24,6 +23,7 @@ import (
 	udm_context "github.com/omec-project/udm/context"
 	"github.com/omec-project/udm/logger"
 	"github.com/omec-project/udm/util"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/util/ueauth"
 	"github.com/omec-project/util_3gpp/suci"
 )
@@ -85,7 +85,7 @@ func strictHex(s string, n int) string {
 	}
 }
 
-func HandleGenerateAuthDataRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleGenerateAuthDataRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	// step 1: log
 	logger.UeauLog.Infoln("Handle GenerateAuthDataRequest")
 
@@ -99,18 +99,18 @@ func HandleGenerateAuthDataRequest(request *http_wrapper.Request) *http_wrapper.
 	// step 4: process the return value from step 3
 	if response != nil {
 		// status code is based on SPEC, and option headers
-		return http_wrapper.NewResponse(http.StatusOK, nil, response)
+		return httpwrapper.NewResponse(http.StatusOK, nil, response)
 	} else if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 	problemDetails = &models.ProblemDetails{
 		Status: http.StatusForbidden,
 		Cause:  "UNSPECIFIED",
 	}
-	return http_wrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
+	return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 }
 
-func HandleConfirmAuthDataRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleConfirmAuthDataRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	logger.UeauLog.Infoln("Handle ConfirmAuthDataRequest")
 
 	authEvent := request.Body.(models.AuthEvent)
@@ -119,9 +119,9 @@ func HandleConfirmAuthDataRequest(request *http_wrapper.Request) *http_wrapper.R
 	problemDetails := ConfirmAuthDataProcedure(authEvent, supi)
 
 	if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	} else {
-		return http_wrapper.NewResponse(http.StatusCreated, nil, nil)
+		return httpwrapper.NewResponse(http.StatusCreated, nil, nil)
 	}
 }
 

--- a/producer/parameter_provision.go
+++ b/producer/parameter_provision.go
@@ -9,14 +9,14 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/omec-project/http_wrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/udm/logger"
 	"github.com/omec-project/udm/util"
+	"github.com/omec-project/util/httpwrapper"
 )
 
-func HandleUpdateRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleUpdateRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	// step 1: log
 	logger.PpLog.Infoln("Handle UpdateRequest")
 
@@ -29,9 +29,9 @@ func HandleUpdateRequest(request *http_wrapper.Request) *http_wrapper.Response {
 
 	// step 4: process the return value from step 3
 	if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	} else {
-		return http_wrapper.NewResponse(http.StatusNoContent, nil, nil)
+		return httpwrapper.NewResponse(http.StatusNoContent, nil, nil)
 	}
 }
 

--- a/producer/subscriber_data_management.go
+++ b/producer/subscriber_data_management.go
@@ -12,7 +12,6 @@ import (
 	"strconv"
 
 	"github.com/antihax/optional"
-	"github.com/omec-project/http_wrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/Nudm_SubscriberDataManagement"
 	Nudr "github.com/omec-project/openapi/Nudr_DataRepository"
@@ -20,9 +19,10 @@ import (
 	udm_context "github.com/omec-project/udm/context"
 	"github.com/omec-project/udm/logger"
 	"github.com/omec-project/udm/util"
+	"github.com/omec-project/util/httpwrapper"
 )
 
-func HandleGetAmDataRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleGetAmDataRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	// step 1: log
 	logger.SdmLog.Infof("Handle GetAmData")
 
@@ -37,15 +37,15 @@ func HandleGetAmDataRequest(request *http_wrapper.Request) *http_wrapper.Respons
 	// step 4: process the return value from step 3
 	if response != nil {
 		// status code is based on SPEC, and option headers
-		return http_wrapper.NewResponse(http.StatusOK, nil, response)
+		return httpwrapper.NewResponse(http.StatusOK, nil, response)
 	} else if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 	problemDetails = &models.ProblemDetails{
 		Status: http.StatusForbidden,
 		Cause:  "UNSPECIFIED",
 	}
-	return http_wrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
+	return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 }
 
 // GetAmDataProcedure
@@ -95,7 +95,7 @@ func getAmDataProcedure(supi string, plmnID string, supportedFeatures string) (
 	}
 }
 
-func HandleGetIdTranslationResultRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleGetIdTranslationResultRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	// step 1: log
 	logger.SdmLog.Infof("Handle GetIdTranslationResultRequest")
 
@@ -108,15 +108,15 @@ func HandleGetIdTranslationResultRequest(request *http_wrapper.Request) *http_wr
 	// step 4: process the return value from step 3
 	if response != nil {
 		// status code is based on SPEC, and option headers
-		return http_wrapper.NewResponse(http.StatusOK, nil, response)
+		return httpwrapper.NewResponse(http.StatusOK, nil, response)
 	} else if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 	problemDetails = &models.ProblemDetails{
 		Status: http.StatusForbidden,
 		Cause:  "UNSPECIFIED",
 	}
-	return http_wrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
+	return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 }
 
 func getIdTranslationResultProcedure(gpsi string) (response *models.IdTranslationResult,
@@ -178,7 +178,7 @@ func getIdTranslationResultProcedure(gpsi string) (response *models.IdTranslatio
 	}
 }
 
-func HandleGetSupiRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleGetSupiRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	// step 1: log
 	logger.SdmLog.Infof("Handle GetSupiRequest")
 
@@ -194,15 +194,15 @@ func HandleGetSupiRequest(request *http_wrapper.Request) *http_wrapper.Response 
 	// step 4: process the return value from step 3
 	if response != nil {
 		// status code is based on SPEC, and option headers
-		return http_wrapper.NewResponse(http.StatusOK, nil, response)
+		return httpwrapper.NewResponse(http.StatusOK, nil, response)
 	} else if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 	problemDetails = &models.ProblemDetails{
 		Status: http.StatusForbidden,
 		Cause:  "UNSPECIFIED",
 	}
-	return http_wrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
+	return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 }
 
 func getSupiProcedure(supi string, plmnID string, dataSetNames []string, supportedFeatures string) (
@@ -444,7 +444,7 @@ func getSupiProcedure(supi string, plmnID string, dataSetNames []string, support
 	}
 }
 
-func HandleGetSharedDataRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleGetSharedDataRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	// step 1: log
 	logger.SdmLog.Infof("Handle GetSharedData")
 
@@ -457,15 +457,15 @@ func HandleGetSharedDataRequest(request *http_wrapper.Request) *http_wrapper.Res
 	// step 4: process the return value from step 3
 	if response != nil {
 		// status code is based on SPEC, and option headers
-		return http_wrapper.NewResponse(http.StatusOK, nil, response)
+		return httpwrapper.NewResponse(http.StatusOK, nil, response)
 	} else if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 	problemDetails = &models.ProblemDetails{
 		Status: http.StatusForbidden,
 		Cause:  "UNSPECIFIED",
 	}
-	return http_wrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
+	return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 }
 
 func getSharedDataProcedure(sharedDataIds []string, supportedFeatures string) (
@@ -516,7 +516,7 @@ func getSharedDataProcedure(sharedDataIds []string, supportedFeatures string) (
 	}
 }
 
-func HandleGetSmDataRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleGetSmDataRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	// step 1: log
 	logger.SdmLog.Infof("Handle GetSmData")
 
@@ -533,15 +533,15 @@ func HandleGetSmDataRequest(request *http_wrapper.Request) *http_wrapper.Respons
 	// step 4: process the return value from step 3
 	if response != nil {
 		// status code is based on SPEC, and option headers
-		return http_wrapper.NewResponse(http.StatusOK, nil, response)
+		return httpwrapper.NewResponse(http.StatusOK, nil, response)
 	} else if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 	problemDetails = &models.ProblemDetails{
 		Status: http.StatusForbidden,
 		Cause:  "UNSPECIFIED",
 	}
-	return http_wrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
+	return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 }
 
 func getSmDataProcedure(supi string, plmnID string, Dnn string, Snssai string, supportedFeatures string) (
@@ -621,7 +621,7 @@ func getSmDataProcedure(supi string, plmnID string, Dnn string, Snssai string, s
 	}
 }
 
-func HandleGetNssaiRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleGetNssaiRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	// step 1: log
 	logger.SdmLog.Infof("Handle GetNssai")
 
@@ -636,15 +636,15 @@ func HandleGetNssaiRequest(request *http_wrapper.Request) *http_wrapper.Response
 	// step 4: process the return value from step 3
 	if response != nil {
 		// status code is based on SPEC, and option headers
-		return http_wrapper.NewResponse(http.StatusOK, nil, response)
+		return httpwrapper.NewResponse(http.StatusOK, nil, response)
 	} else if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 	problemDetails = &models.ProblemDetails{
 		Status: http.StatusForbidden,
 		Cause:  "UNSPECIFIED",
 	}
-	return http_wrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
+	return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 }
 
 func getNssaiProcedure(supi string, plmnID string, supportedFeatures string) (
@@ -697,7 +697,7 @@ func getNssaiProcedure(supi string, plmnID string, supportedFeatures string) (
 	}
 }
 
-func HandleGetSmfSelectDataRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleGetSmfSelectDataRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	// step 1: log
 	logger.SdmLog.Infof("Handle GetSmfSelectData")
 
@@ -712,15 +712,15 @@ func HandleGetSmfSelectDataRequest(request *http_wrapper.Request) *http_wrapper.
 	// step 4: process the return value from step 3
 	if response != nil {
 		// status code is based on SPEC, and option headers
-		return http_wrapper.NewResponse(http.StatusOK, nil, response)
+		return httpwrapper.NewResponse(http.StatusOK, nil, response)
 	} else if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 	problemDetails = &models.ProblemDetails{
 		Status: http.StatusForbidden,
 		Cause:  "UNSPECIFIED",
 	}
-	return http_wrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
+	return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 }
 
 func getSmfSelectDataProcedure(supi string, plmnID string, supportedFeatures string) (
@@ -774,7 +774,7 @@ func getSmfSelectDataProcedure(supi string, plmnID string, supportedFeatures str
 	}
 }
 
-func HandleSubscribeToSharedDataRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleSubscribeToSharedDataRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	// step 1: log
 	logger.SdmLog.Infof("Handle SubscribeToSharedData")
 
@@ -787,11 +787,11 @@ func HandleSubscribeToSharedDataRequest(request *http_wrapper.Request) *http_wra
 	// step 4: process the return value from step 3
 	if response != nil {
 		// status code is based on SPEC, and option headers
-		return http_wrapper.NewResponse(http.StatusCreated, header, response)
+		return httpwrapper.NewResponse(http.StatusCreated, header, response)
 	} else if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	} else {
-		return http_wrapper.NewResponse(http.StatusNotFound, nil, nil)
+		return httpwrapper.NewResponse(http.StatusNotFound, nil, nil)
 	}
 }
 
@@ -846,7 +846,7 @@ func subscribeToSharedDataProcedure(sdmSubscription *models.SdmSubscription) (
 	}
 }
 
-func HandleSubscribeRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleSubscribeRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	// step 1: log
 	logger.SdmLog.Infof("Handle Subscribe")
 
@@ -860,11 +860,11 @@ func HandleSubscribeRequest(request *http_wrapper.Request) *http_wrapper.Respons
 	// step 4: process the return value from step 3
 	if response != nil {
 		// status code is based on SPEC, and option headers
-		return http_wrapper.NewResponse(http.StatusCreated, header, response)
+		return httpwrapper.NewResponse(http.StatusCreated, header, response)
 	} else if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	} else {
-		return http_wrapper.NewResponse(http.StatusNotFound, nil, nil)
+		return httpwrapper.NewResponse(http.StatusNotFound, nil, nil)
 	}
 }
 
@@ -923,7 +923,7 @@ func subscribeProcedure(sdmSubscription *models.SdmSubscription, supi string) (
 	}
 }
 
-func HandleUnsubscribeForSharedDataRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleUnsubscribeForSharedDataRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	logger.SdmLog.Infof("Handle UnsubscribeForSharedData")
 
 	// step 2: retrieve request
@@ -933,10 +933,10 @@ func HandleUnsubscribeForSharedDataRequest(request *http_wrapper.Request) *http_
 
 	// step 4: process the return value from step 3
 	if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 
-	return http_wrapper.NewResponse(http.StatusNoContent, nil, nil)
+	return httpwrapper.NewResponse(http.StatusNoContent, nil, nil)
 }
 
 func unsubscribeForSharedDataProcedure(subscriptionID string) *models.ProblemDetails {
@@ -977,7 +977,7 @@ func unsubscribeForSharedDataProcedure(subscriptionID string) *models.ProblemDet
 	}
 }
 
-func HandleUnsubscribeRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleUnsubscribeRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	logger.SdmLog.Infof("Handle Unsubscribe")
 
 	// step 2: retrieve request
@@ -989,10 +989,10 @@ func HandleUnsubscribeRequest(request *http_wrapper.Request) *http_wrapper.Respo
 
 	// step 4: process the return value from step 3
 	if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 
-	return http_wrapper.NewResponse(http.StatusNoContent, nil, nil)
+	return httpwrapper.NewResponse(http.StatusNoContent, nil, nil)
 }
 
 func unsubscribeProcedure(supi string, subscriptionID string) *models.ProblemDetails {
@@ -1034,7 +1034,7 @@ func unsubscribeProcedure(supi string, subscriptionID string) *models.ProblemDet
 	}
 }
 
-func HandleModifyRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleModifyRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	// step 1: log
 	logger.SdmLog.Infof("Handle Modify")
 
@@ -1049,15 +1049,15 @@ func HandleModifyRequest(request *http_wrapper.Request) *http_wrapper.Response {
 	// step 4: process the return value from step 3
 	if response != nil {
 		// status code is based on SPEC, and option headers
-		return http_wrapper.NewResponse(http.StatusOK, nil, response)
+		return httpwrapper.NewResponse(http.StatusOK, nil, response)
 	} else if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 	problemDetails = &models.ProblemDetails{
 		Status: http.StatusForbidden,
 		Cause:  "UNSPECIFIED",
 	}
-	return http_wrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
+	return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 }
 
 func modifyProcedure(sdmSubsModification *models.SdmSubsModification, supi string, subscriptionID string) (
@@ -1106,7 +1106,7 @@ func modifyProcedure(sdmSubsModification *models.SdmSubsModification, supi strin
 	}
 }
 
-func HandleModifyForSharedDataRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleModifyForSharedDataRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	// step 1: log
 	logger.SdmLog.Infof("Handle ModifyForSharedData")
 
@@ -1121,15 +1121,15 @@ func HandleModifyForSharedDataRequest(request *http_wrapper.Request) *http_wrapp
 	// step 4: process the return value from step 3
 	if response != nil {
 		// status code is based on SPEC, and option headers
-		return http_wrapper.NewResponse(http.StatusOK, nil, response)
+		return httpwrapper.NewResponse(http.StatusOK, nil, response)
 	} else if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 	problemDetails = &models.ProblemDetails{
 		Status: http.StatusForbidden,
 		Cause:  "UNSPECIFIED",
 	}
-	return http_wrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
+	return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 }
 
 func modifyForSharedDataProcedure(sdmSubsModification *models.SdmSubsModification, supi string,
@@ -1180,7 +1180,7 @@ func modifyForSharedDataProcedure(sdmSubsModification *models.SdmSubsModificatio
 	}
 }
 
-func HandleGetTraceDataRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleGetTraceDataRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	// step 1: log
 	logger.SdmLog.Infof("Handle GetTraceData")
 
@@ -1194,15 +1194,15 @@ func HandleGetTraceDataRequest(request *http_wrapper.Request) *http_wrapper.Resp
 	// step 4: process the return value from step 3
 	if response != nil {
 		// status code is based on SPEC, and option headers
-		return http_wrapper.NewResponse(http.StatusOK, nil, response)
+		return httpwrapper.NewResponse(http.StatusOK, nil, response)
 	} else if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 	problemDetails = &models.ProblemDetails{
 		Status: http.StatusForbidden,
 		Cause:  "UNSPECIFIED",
 	}
-	return http_wrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
+	return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 }
 
 func getTraceDataProcedure(supi string, plmnID string) (
@@ -1257,7 +1257,7 @@ func getTraceDataProcedure(supi string, plmnID string) (
 	}
 }
 
-func HandleGetUeContextInSmfDataRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleGetUeContextInSmfDataRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	// step 1: log
 	logger.SdmLog.Infof("Handle GetUeContextInSmfData")
 
@@ -1271,15 +1271,15 @@ func HandleGetUeContextInSmfDataRequest(request *http_wrapper.Request) *http_wra
 	// step 4: process the return value from step 3
 	if response != nil {
 		// status code is based on SPEC, and option headers
-		return http_wrapper.NewResponse(http.StatusOK, nil, response)
+		return httpwrapper.NewResponse(http.StatusOK, nil, response)
 	} else if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 	problemDetails = &models.ProblemDetails{
 		Status: http.StatusForbidden,
 		Cause:  "UNSPECIFIED",
 	}
-	return http_wrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
+	return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 }
 
 func getUeContextInSmfDataProcedure(supi string, supportedFeatures string) (

--- a/producer/ue_context_management.go
+++ b/producer/ue_context_management.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 
 	"github.com/antihax/optional"
-	"github.com/omec-project/http_wrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/Nudr_DataRepository"
 	"github.com/omec-project/openapi/models"
@@ -22,6 +21,7 @@ import (
 	"github.com/omec-project/udm/logger"
 	"github.com/omec-project/udm/producer/callback"
 	"github.com/omec-project/udm/util"
+	"github.com/omec-project/util/httpwrapper"
 )
 
 func createUDMClientToUDR(id string) (*Nudr_DataRepository.APIClient, error) {
@@ -73,7 +73,7 @@ func getUdrURI(id string) string {
 	return consumer.SendNFIntancesUDR("", consumer.NFDiscoveryToUDRParamNone)
 }
 
-func HandleGetAmf3gppAccessRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleGetAmf3gppAccessRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	// step 1: log
 	logger.UecmLog.Infof("Handle HandleGetAmf3gppAccessRequest")
 
@@ -87,15 +87,15 @@ func HandleGetAmf3gppAccessRequest(request *http_wrapper.Request) *http_wrapper.
 	// step 4: process the return value from step 3
 	if response != nil {
 		// status code is based on SPEC, and option headers
-		return http_wrapper.NewResponse(http.StatusOK, nil, response)
+		return httpwrapper.NewResponse(http.StatusOK, nil, response)
 	} else if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 	problemDetails = &models.ProblemDetails{
 		Status: http.StatusForbidden,
 		Cause:  "UNSPECIFIED",
 	}
-	return http_wrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
+	return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 }
 
 func GetAmf3gppAccessProcedure(ueID string, supportedFeatures string) (
@@ -128,7 +128,7 @@ func GetAmf3gppAccessProcedure(ueID string, supportedFeatures string) (
 	return &amf3GppAccessRegistration, nil
 }
 
-func HandleGetAmfNon3gppAccessRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleGetAmfNon3gppAccessRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	// step 1: log
 	logger.UecmLog.Infoln("Handle GetAmfNon3gppAccessRequest")
 
@@ -144,15 +144,15 @@ func HandleGetAmfNon3gppAccessRequest(request *http_wrapper.Request) *http_wrapp
 	// step 4: process the return value from step 3
 	if response != nil {
 		// status code is based on SPEC, and option headers
-		return http_wrapper.NewResponse(http.StatusOK, nil, response)
+		return httpwrapper.NewResponse(http.StatusOK, nil, response)
 	} else if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 	problemDetails = &models.ProblemDetails{
 		Status: http.StatusForbidden,
 		Cause:  "UNSPECIFIED",
 	}
-	return http_wrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
+	return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 }
 
 func GetAmfNon3gppAccessProcedure(queryAmfContextNon3gppParamOpts Nudr_DataRepository.
@@ -183,7 +183,7 @@ func GetAmfNon3gppAccessProcedure(queryAmfContextNon3gppParamOpts Nudr_DataRepos
 	return &amfNon3GppAccessRegistration, nil
 }
 
-func HandleRegistrationAmf3gppAccessRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleRegistrationAmf3gppAccessRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	// step 1: log
 	logger.UecmLog.Infof("Handle RegistrationAmf3gppAccess")
 
@@ -198,11 +198,11 @@ func HandleRegistrationAmf3gppAccessRequest(request *http_wrapper.Request) *http
 	// step 4: process the return value from step 3
 	if response != nil {
 		// status code is based on SPEC, and option headers
-		return http_wrapper.NewResponse(http.StatusCreated, header, response)
+		return httpwrapper.NewResponse(http.StatusCreated, header, response)
 	} else if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	} else {
-		return http_wrapper.NewResponse(http.StatusNoContent, nil, nil)
+		return httpwrapper.NewResponse(http.StatusNoContent, nil, nil)
 	}
 }
 
@@ -264,7 +264,7 @@ func RegistrationAmf3gppAccessProcedure(registerRequest models.Amf3GppAccessRegi
 }
 
 // TS 29.503 5.3.2.2.3
-func HandleRegisterAmfNon3gppAccessRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleRegisterAmfNon3gppAccessRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	// step 1: log
 	logger.UecmLog.Infof("Handle RegisterAmfNon3gppAccessRequest")
 
@@ -278,11 +278,11 @@ func HandleRegisterAmfNon3gppAccessRequest(request *http_wrapper.Request) *http_
 	// step 4: process the return value from step 3
 	if response != nil {
 		// status code is based on SPEC, and option headers
-		return http_wrapper.NewResponse(http.StatusCreated, header, response)
+		return httpwrapper.NewResponse(http.StatusCreated, header, response)
 	} else if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	} else {
-		return http_wrapper.NewResponse(http.StatusNoContent, nil, nil)
+		return httpwrapper.NewResponse(http.StatusNoContent, nil, nil)
 	}
 }
 
@@ -341,7 +341,7 @@ func RegisterAmfNon3gppAccessProcedure(registerRequest models.AmfNon3GppAccessRe
 }
 
 // TODO: ueID may be SUPI or GPSI, but this function did not handle this condition
-func HandleUpdateAmf3gppAccessRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleUpdateAmf3gppAccessRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	// step 1: log
 	logger.UecmLog.Infof("Handle UpdateAmf3gppAccessRequest")
 
@@ -354,9 +354,9 @@ func HandleUpdateAmf3gppAccessRequest(request *http_wrapper.Request) *http_wrapp
 
 	// step 4: process the return value from step 3
 	if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	} else {
-		return http_wrapper.NewResponse(http.StatusNoContent, nil, nil)
+		return httpwrapper.NewResponse(http.StatusNoContent, nil, nil)
 	}
 }
 
@@ -453,7 +453,7 @@ func UpdateAmf3gppAccessProcedure(request models.Amf3GppAccessRegistrationModifi
 }
 
 // TODO: ueID may be SUPI or GPSI, but this function did not handle this condition
-func HandleUpdateAmfNon3gppAccessRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleUpdateAmfNon3gppAccessRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	// step 1: log
 	logger.UecmLog.Infof("Handle UpdateAmfNon3gppAccessRequest")
 
@@ -466,9 +466,9 @@ func HandleUpdateAmfNon3gppAccessRequest(request *http_wrapper.Request) *http_wr
 
 	// step 4: process the return value from step 3
 	if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	} else {
-		return http_wrapper.NewResponse(http.StatusNoContent, nil, nil)
+		return httpwrapper.NewResponse(http.StatusNoContent, nil, nil)
 	}
 }
 
@@ -563,7 +563,7 @@ func UpdateAmfNon3gppAccessProcedure(request models.AmfNon3GppAccessRegistration
 	return nil
 }
 
-func HandleDeregistrationSmfRegistrations(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleDeregistrationSmfRegistrations(request *httpwrapper.Request) *httpwrapper.Response {
 	// step 1: log
 	logger.UecmLog.Infof("Handle DeregistrationSmfRegistrations")
 
@@ -576,9 +576,9 @@ func HandleDeregistrationSmfRegistrations(request *http_wrapper.Request) *http_w
 
 	// step 4: process the return value from step 3
 	if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	} else {
-		return http_wrapper.NewResponse(http.StatusNoContent, nil, nil)
+		return httpwrapper.NewResponse(http.StatusNoContent, nil, nil)
 	}
 }
 
@@ -607,7 +607,7 @@ func DeregistrationSmfRegistrationsProcedure(ueID string, pduSessionID string) (
 }
 
 // SmfRegistrations
-func HandleRegistrationSmfRegistrationsRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleRegistrationSmfRegistrationsRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	// step 1: log
 	logger.UecmLog.Infof("Handle RegistrationSmfRegistrations")
 
@@ -622,12 +622,12 @@ func HandleRegistrationSmfRegistrationsRequest(request *http_wrapper.Request) *h
 	// step 4: process the return value from step 3
 	if response != nil {
 		// status code is based on SPEC, and option headers
-		return http_wrapper.NewResponse(http.StatusCreated, header, response)
+		return httpwrapper.NewResponse(http.StatusCreated, header, response)
 	} else if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	} else {
 		// all nil
-		return http_wrapper.NewResponse(http.StatusNoContent, nil, nil)
+		return httpwrapper.NewResponse(http.StatusNoContent, nil, nil)
 	}
 }
 

--- a/subscriberdatamanagement/api_access_and_mobility_subscription_data_retrieval.go
+++ b/subscriberdatamanagement/api_access_and_mobility_subscription_data_retrieval.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/udm/logger"
@@ -28,7 +28,7 @@ import (
 
 // GetAmData - retrieve a UE's Access and Mobility Subscription Data
 func HTTPGetAmData(c *gin.Context) {
-	req := http_wrapper.NewRequest(c.Request, nil)
+	req := httpwrapper.NewRequest(c.Request, nil)
 	req.Params["supi"] = c.Params.ByName("supi")
 	req.Query.Set("plmn-id", c.Query("plmn-id"))
 	req.Query.Set("supported-features", c.Query("plmn-id"))

--- a/subscriberdatamanagement/api_gpsi_to_supi_translation.go
+++ b/subscriberdatamanagement/api_gpsi_to_supi_translation.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/udm/logger"
@@ -28,7 +28,7 @@ import (
 
 // GetIdTranslationResult - retrieve a UE's SUPI
 func HTTPGetIdTranslationResult(c *gin.Context) {
-	req := http_wrapper.NewRequest(c.Request, nil)
+	req := httpwrapper.NewRequest(c.Request, nil)
 	req.Params["gpsi"] = c.Params.ByName("gpsi")
 	req.Query.Set("SupportedFeatures", c.Query("supported-features"))
 

--- a/subscriberdatamanagement/api_retrieval_of_multiple_data_sets.go
+++ b/subscriberdatamanagement/api_retrieval_of_multiple_data_sets.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/udm/logger"
@@ -28,7 +28,7 @@ import (
 
 // GetSupi - retrieve multiple data sets
 func HTTPGetSupi(c *gin.Context) {
-	req := http_wrapper.NewRequest(c.Request, nil)
+	req := httpwrapper.NewRequest(c.Request, nil)
 	req.Params["supi"] = c.Params.ByName("supi")
 	req.Query.Set("plmn-id", c.Query("plmn-id"))
 	req.Query.Set("dataset-names", c.Query("dataset-names"))

--- a/subscriberdatamanagement/api_retrieval_of_shared_data.go
+++ b/subscriberdatamanagement/api_retrieval_of_shared_data.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/udm/logger"
@@ -28,7 +28,7 @@ import (
 
 // GetSharedData - retrieve shared data
 func HTTPGetSharedData(c *gin.Context) {
-	req := http_wrapper.NewRequest(c.Request, nil)
+	req := httpwrapper.NewRequest(c.Request, nil)
 	req.Query["sharedDataIds"] = c.QueryArray("shared-data-ids")
 	req.Query["supported-features"] = c.QueryArray("supported-features")
 

--- a/subscriberdatamanagement/api_session_management_subscription_data_retrieval.go
+++ b/subscriberdatamanagement/api_session_management_subscription_data_retrieval.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/udm/logger"
@@ -28,7 +28,7 @@ import (
 
 // GetSmData - retrieve a UE's Session Management Subscription Data
 func HTTPGetSmData(c *gin.Context) {
-	req := http_wrapper.NewRequest(c.Request, nil)
+	req := httpwrapper.NewRequest(c.Request, nil)
 	req.Params["supi"] = c.Param("supi")
 	req.Query.Set("plmn-id", c.Query("plmn-id"))
 	req.Query.Set("dnn", c.Query("dnn"))

--- a/subscriberdatamanagement/api_slice_selection_subscription_data_retrieval.go
+++ b/subscriberdatamanagement/api_slice_selection_subscription_data_retrieval.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/udm/logger"
@@ -28,7 +28,7 @@ import (
 
 // GetNssai - retrieve a UE's subscribed NSSAI
 func HTTPGetNssai(c *gin.Context) {
-	req := http_wrapper.NewRequest(c.Request, nil)
+	req := httpwrapper.NewRequest(c.Request, nil)
 	req.Params["supi"] = c.Params.ByName("supi")
 	req.Query.Set("plmn-id", c.Query("plmn-id"))
 	req.Query.Set("supported-features", c.Query("supported-features"))

--- a/subscriberdatamanagement/api_smf_selection_subscription_data_retrieval.go
+++ b/subscriberdatamanagement/api_smf_selection_subscription_data_retrieval.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/udm/logger"
@@ -28,7 +28,7 @@ import (
 
 // GetSmfSelectData - retrieve a UE's SMF Selection Subscription Data
 func HTTPGetSmfSelectData(c *gin.Context) {
-	req := http_wrapper.NewRequest(c.Request, nil)
+	req := httpwrapper.NewRequest(c.Request, nil)
 	req.Params["supi"] = c.Params.ByName("supi")
 	req.Query.Set("plmn-id", c.Query("plmn-id"))
 	req.Query.Set("supported-features", c.Query("supported-features"))

--- a/subscriberdatamanagement/api_subscription_creation.go
+++ b/subscriberdatamanagement/api_subscription_creation.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/udm/logger"
@@ -58,7 +58,7 @@ func HTTPSubscribe(c *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(c.Request, sdmSubscriptionReq)
+	req := httpwrapper.NewRequest(c.Request, sdmSubscriptionReq)
 	req.Params["supi"] = c.Params.ByName("supi")
 
 	rsp := producer.HandleSubscribeRequest(req)

--- a/subscriberdatamanagement/api_subscription_creation_for_shared_data.go
+++ b/subscriberdatamanagement/api_subscription_creation_for_shared_data.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/udm/logger"
@@ -57,7 +57,7 @@ func HTTPSubscribeToSharedData(c *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(c.Request, sharedDataSubsReq)
+	req := httpwrapper.NewRequest(c.Request, sharedDataSubsReq)
 	rsp := producer.HandleSubscribeToSharedDataRequest(req)
 	// step 5: response
 	for key, val := range rsp.Header { // header response is optional

--- a/subscriberdatamanagement/api_subscription_deletion.go
+++ b/subscriberdatamanagement/api_subscription_deletion.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/udm/logger"
@@ -28,7 +28,7 @@ import (
 
 // Unsubscribe - unsubscribe from notifications
 func HTTPUnsubscribe(c *gin.Context) {
-	req := http_wrapper.NewRequest(c.Request, nil)
+	req := httpwrapper.NewRequest(c.Request, nil)
 	req.Params["ueId"] = c.Params.ByName("ueId")
 	req.Params["subscriptionId"] = c.Params.ByName("subscriptionId")
 

--- a/subscriberdatamanagement/api_subscription_deletion_for_shared_data.go
+++ b/subscriberdatamanagement/api_subscription_deletion_for_shared_data.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/udm/logger"
@@ -28,7 +28,7 @@ import (
 
 // UnsubscribeForSharedData - unsubscribe from notifications for shared data
 func HTTPUnsubscribeForSharedData(c *gin.Context) {
-	req := http_wrapper.NewRequest(c.Request, nil)
+	req := httpwrapper.NewRequest(c.Request, nil)
 	req.Params["subscriptionId"] = c.Params.ByName("subscriptionId")
 
 	rsp := producer.HandleUnsubscribeForSharedDataRequest(req)

--- a/subscriberdatamanagement/api_subscription_modification.go
+++ b/subscriberdatamanagement/api_subscription_modification.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/udm/logger"
@@ -57,7 +57,7 @@ func HTTPModify(c *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(c.Request, sdmSubsModificationReq)
+	req := httpwrapper.NewRequest(c.Request, sdmSubsModificationReq)
 	req.Params["supi"] = c.Params.ByName("supi")
 	req.Params["subscriptionId"] = c.Params.ByName("subscriptionId")
 
@@ -107,7 +107,7 @@ func HTTPModifyForSharedData(c *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(c.Request, sharedDataSubscriptions)
+	req := httpwrapper.NewRequest(c.Request, sharedDataSubscriptions)
 	req.Params["supi"] = c.Params.ByName("supi")
 	req.Params["subscriptionId"] = c.Params.ByName("subscriptionId")
 

--- a/subscriberdatamanagement/api_trace_configuration_data_retrieval.go
+++ b/subscriberdatamanagement/api_trace_configuration_data_retrieval.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/udm/logger"
@@ -28,7 +28,7 @@ import (
 
 // GetTraceData - retrieve a UE's Trace Configuration Data
 func HTTPGetTraceData(c *gin.Context) {
-	req := http_wrapper.NewRequest(c.Request, nil)
+	req := httpwrapper.NewRequest(c.Request, nil)
 	req.Params["supi"] = c.Params.ByName("supi")
 	req.Query.Set("plmn-id", c.Query("plmn-id"))
 

--- a/subscriberdatamanagement/api_ue_context_in_smf_data_retrieval.go
+++ b/subscriberdatamanagement/api_ue_context_in_smf_data_retrieval.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/udm/logger"
@@ -28,7 +28,7 @@ import (
 
 // GetUeContextInSmfData - retrieve a UE's UE Context In SMF Data
 func HTTPGetUeContextInSmfData(c *gin.Context) {
-	req := http_wrapper.NewRequest(c.Request, nil)
+	req := httpwrapper.NewRequest(c.Request, nil)
 	req.Params["supi"] = c.Params.ByName("supi")
 	req.Query.Set("supported-features", c.Query("supported-features"))
 

--- a/ueauthentication/api_confirm_auth.go
+++ b/ueauthentication/api_confirm_auth.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/udm/logger"
@@ -57,7 +57,7 @@ func HTTPConfirmAuth(c *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(c.Request, authEvent)
+	req := httpwrapper.NewRequest(c.Request, authEvent)
 	req.Params["supi"] = c.Params.ByName("supi")
 
 	rsp := producer.HandleConfirmAuthDataRequest(req)

--- a/ueauthentication/api_generate_auth_data.go
+++ b/ueauthentication/api_generate_auth_data.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/udm/logger"
@@ -58,7 +58,7 @@ func HttpGenerateAuthData(c *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(c.Request, authInfoReq)
+	req := httpwrapper.NewRequest(c.Request, authInfoReq)
 	req.Params["supiOrSuci"] = c.Param("supiOrSuci")
 
 	rsp := producer.HandleGenerateAuthDataRequest(req)

--- a/uecontextmanagement/api_amf3_gpp_access_registration_info_retrieval.go
+++ b/uecontextmanagement/api_amf3_gpp_access_registration_info_retrieval.go
@@ -20,7 +20,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	// "fmt"
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/udm/logger"
@@ -29,7 +29,7 @@ import (
 
 // GetAmf3gppAccess - retrieve the AMF registration for 3GPP access information
 func HTTPGetAmf3gppAccess(c *gin.Context) {
-	req := http_wrapper.NewRequest(c.Request, nil)
+	req := httpwrapper.NewRequest(c.Request, nil)
 	req.Params["ueId"] = c.Param("ueId")
 	req.Query.Add("supported-features", c.Query("supported-features"))
 

--- a/uecontextmanagement/api_amf_non3_gpp_access_registration_info_retrieval.go
+++ b/uecontextmanagement/api_amf_non3_gpp_access_registration_info_retrieval.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/udm/logger"
@@ -28,7 +28,7 @@ import (
 
 // GetAmfNon3gppAccess - retrieve the AMF registration for non-3GPP access information
 func HTTPGetAmfNon3gppAccess(c *gin.Context) {
-	req := http_wrapper.NewRequest(c.Request, nil)
+	req := httpwrapper.NewRequest(c.Request, nil)
 	req.Params["ueId"] = c.Param("ueId")
 	req.Query.Add("supported-features", c.Query("supported-features"))
 

--- a/uecontextmanagement/api_amf_registration_for3_gpp_access.go
+++ b/uecontextmanagement/api_amf_registration_for3_gpp_access.go
@@ -20,7 +20,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	// "fmt"
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/udm/logger"
@@ -58,7 +58,7 @@ func HTTPRegistrationAmf3gppAccess(c *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(c.Request, amf3GppAccessRegistration)
+	req := httpwrapper.NewRequest(c.Request, amf3GppAccessRegistration)
 	req.Params["ueId"] = c.Param("ueId")
 
 	rsp := producer.HandleRegistrationAmf3gppAccessRequest(req)

--- a/uecontextmanagement/api_amf_registration_for_non3_gpp_access.go
+++ b/uecontextmanagement/api_amf_registration_for_non3_gpp_access.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/udm/logger"
@@ -58,7 +58,7 @@ func HTTPRegistrationAmfNon3gppAccess(c *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(c.Request, amfNon3GppAccessRegistration)
+	req := httpwrapper.NewRequest(c.Request, amfNon3GppAccessRegistration)
 	req.Params["ueId"] = c.Param("ueId")
 
 	rsp := producer.HandleRegisterAmfNon3gppAccessRequest(req)

--- a/uecontextmanagement/api_parameter_update_in_the_amf_registration_for3_gpp_access.go
+++ b/uecontextmanagement/api_parameter_update_in_the_amf_registration_for3_gpp_access.go
@@ -20,7 +20,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	// "fmt"
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/udm/logger"
@@ -59,7 +59,7 @@ func HTTPUpdateAmf3gppAccess(c *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(c.Request, amf3GppAccessRegistrationModification)
+	req := httpwrapper.NewRequest(c.Request, amf3GppAccessRegistrationModification)
 	req.Params["ueId"] = c.Param("ueId")
 
 	rsp := producer.HandleUpdateAmf3gppAccessRequest(req)

--- a/uecontextmanagement/api_parameter_update_in_the_amf_registration_for_non3_gpp_access.go
+++ b/uecontextmanagement/api_parameter_update_in_the_amf_registration_for_non3_gpp_access.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/udm/logger"
@@ -57,7 +57,7 @@ func HTTPUpdateAmfNon3gppAccess(c *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(c.Request, amfNon3GppAccessRegistrationModification)
+	req := httpwrapper.NewRequest(c.Request, amfNon3GppAccessRegistrationModification)
 	req.Params["ueId"] = c.Param("ueId")
 
 	rsp := producer.HandleUpdateAmfNon3gppAccessRequest(req)

--- a/uecontextmanagement/api_smf_deregistration.go
+++ b/uecontextmanagement/api_smf_deregistration.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/udm/logger"
@@ -28,7 +28,7 @@ import (
 
 // DeregistrationSmfRegistrations - delete an SMF registration
 func HTTPDeregistrationSmfRegistrations(c *gin.Context) {
-	req := http_wrapper.NewRequest(c.Request, nil)
+	req := httpwrapper.NewRequest(c.Request, nil)
 	req.Params["ueId"] = c.Params.ByName("ueId")
 	req.Params["pduSessionId"] = c.Params.ByName("pduSessionId")
 

--- a/uecontextmanagement/api_smf_registration.go
+++ b/uecontextmanagement/api_smf_registration.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/udm/logger"
@@ -57,7 +57,7 @@ func HTTPRegistrationSmfRegistrations(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, rsp)
 		return
 	}
-	req := http_wrapper.NewRequest(c.Request, smfRegistration)
+	req := httpwrapper.NewRequest(c.Request, smfRegistration)
 	req.Params["ueId"] = c.Params.ByName("ueId")
 	req.Params["pduSessionId"] = c.Params.ByName("pduSessionId")
 


### PR DESCRIPTION
Moves the `http_wrapper` dependency to the `util` project. Tested with a successful `gnbsim` simulation.