### PR TITLE
Enable linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -218,7 +218,7 @@ linters:
     - errcheck
     - staticcheck
     - unused
-    # - gosimple
+    - gosimple
     # - ineffassign
     - typecheck
     # Additional
@@ -243,7 +243,7 @@ linters:
     - asciicheck
       #- stylecheck
       # - unparam
-      #- wsl
+      # - wsl
 
   #disable-all: false
   fast: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -234,7 +234,7 @@ linters:
     - gci
     - misspell
     - gofumpt
-    # - whitespace
+    - whitespace
     - unconvert
     - predeclared
     - noctx

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -231,7 +231,7 @@ linters:
     # - nestif
     # - gomodguard
     # - nakedret
-    # - gci
+    - gci
     - misspell
     - gofumpt
     # - whitespace

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -219,7 +219,7 @@ linters:
     - staticcheck
     - unused
     - gosimple
-    # - ineffassign
+    - ineffassign
     - typecheck
     # Additional
     # - lll
@@ -227,7 +227,6 @@ linters:
     #- gomnd
     #- goconst
     # - gocognit
-    # - maligned
     # - nestif
     # - gomodguard
     # - nakedret

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -225,7 +225,7 @@ linters:
     # - lll
     - godox
     #- gomnd
-    #- goconst
+    - goconst
     # - gocognit
     # - nestif
     # - gomodguard

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 # Copyright 2019 free5GC.org
 #
 # SPDX-License-Identifier: Apache-2.0
-# 
+#
 
 # This file contains all available configuration options
 # with their default values.
@@ -233,7 +233,7 @@ linters:
     # - nakedret
     # - gci
     - misspell
-    # - gofumpt
+    - gofumpt
     # - whitespace
     - unconvert
     - predeclared

--- a/eventexposure/routers.go
+++ b/eventexposure/routers.go
@@ -20,8 +20,8 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	logger_util "github.com/omec-project/util/logger"
 	"github.com/omec-project/udm/logger"
+	logger_util "github.com/omec-project/util/logger"
 )
 
 // Route is the information for every URI.

--- a/parameterprovision/routers.go
+++ b/parameterprovision/routers.go
@@ -20,8 +20,8 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	logger_util "github.com/omec-project/util/logger"
 	"github.com/omec-project/udm/logger"
+	logger_util "github.com/omec-project/util/logger"
 )
 
 // Route is the information for every URI.

--- a/producer/event_exposure.go
+++ b/producer/event_exposure.go
@@ -16,6 +16,8 @@ import (
 	"github.com/omec-project/util/httpwrapper"
 )
 
+const anyUE = "anyUE"
+
 func HandleCreateEeSubscription(request *httpwrapper.Request) *httpwrapper.Response {
 	logger.EeLog.Infoln("Handle Create EE Subscription")
 
@@ -96,7 +98,7 @@ func CreateEeSubscriptionProcedure(ueIdentity string,
 		})
 		return createdEeSubscription, nil
 	// represents any UEs
-	case ueIdentity == "anyUE":
+	case ueIdentity == anyUE:
 		id, err := udmSelf.EeSubscriptionIDGenerator.Allocate()
 		if err != nil {
 			problemDetails := &models.ProblemDetails{
@@ -157,7 +159,7 @@ func DeleteEeSubscriptionProcedure(ueIdentity string, subscriptionID string) {
 			}
 			return true
 		})
-	case ueIdentity == "anyUE":
+	case ueIdentity == anyUE:
 		udmSelf.UdmUePool.Range(func(key, value interface{}) bool {
 			ue := value.(*udm_context.UdmUeContext)
 			delete(ue.EeSubscriptions, subscriptionID)
@@ -232,7 +234,7 @@ func UpdateEeSubscriptionProcedure(ueIdentity string, subscriptionID string,
 			return true
 		})
 		return nil
-	case ueIdentity == "anyUE":
+	case ueIdentity == anyUE:
 		udmSelf.UdmUePool.Range(func(key, value interface{}) bool {
 			ue := value.(*udm_context.UdmUeContext)
 			if _, ok := ue.EeSubscriptions[subscriptionID]; ok {

--- a/service/init.go
+++ b/service/init.go
@@ -382,7 +382,7 @@ func (udm *UDM) BuildAndSendRegisterNFInstance() (models.NfProfile, error) {
 		return profile, err
 	}
 	initLog.Infof("UDM Profile Registering to NRF: %v", profile)
-	//Indefinite attempt to register until success
+	// Indefinite attempt to register until success
 	profile, _, self.NfId, err = consumer.SendRegisterNFInstance(self.NrfUri, self.NfId, profile)
 	return profile, err
 }

--- a/service/init.go
+++ b/service/init.go
@@ -323,7 +323,7 @@ func (udm *UDM) updateConfig(commChannel chan *protos.NetworkSliceResponse) bool
 							break
 						}
 					}
-					if found == false {
+					if !found {
 						self.PlmnList = append(self.PlmnList, temp)
 						logger.GrpcLog.Infoln("Plmn added in the context", self.PlmnList)
 					}
@@ -332,7 +332,7 @@ func (udm *UDM) updateConfig(commChannel chan *protos.NetworkSliceResponse) bool
 				}
 			}
 		}
-		if minConfig == false {
+		if !minConfig {
 			// first slice Created
 			if len(self.PlmnList) > 0 {
 				minConfig = true

--- a/subscriberdatamanagement/routers.go
+++ b/subscriberdatamanagement/routers.go
@@ -20,8 +20,8 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	logger_util "github.com/omec-project/util/logger"
 	"github.com/omec-project/udm/logger"
+	logger_util "github.com/omec-project/util/logger"
 )
 
 // Route is the information for every URI.

--- a/ueauthentication/routers.go
+++ b/ueauthentication/routers.go
@@ -21,8 +21,8 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 
-	logger_util "github.com/omec-project/util/logger"
 	"github.com/omec-project/udm/logger"
+	logger_util "github.com/omec-project/util/logger"
 )
 
 var HttpLog *logrus.Entry

--- a/uecontextmanagement/routers.go
+++ b/uecontextmanagement/routers.go
@@ -20,8 +20,8 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	logger_util "github.com/omec-project/util/logger"
 	"github.com/omec-project/udm/logger"
+	logger_util "github.com/omec-project/util/logger"
 )
 
 // Route is the information for every URI.


### PR DESCRIPTION
This PR does the following:
- Enable `gofumpt` linter
- Enable `gci` linter
- Enable `whitespace` linter
- Enable `gosimple` linter
- Enable `ineffassign` linter
- Enable `goconst` linter