### PR TITLE
Encoding Hex fix

### DIFF
--- a/producer/generate_auth_data.go
+++ b/producer/generate_auth_data.go
@@ -79,7 +79,7 @@ func aucSQN(opc, k, auts, rand []byte) ([]byte, []byte) {
 func strictHex(s string, n int) string {
 	l := len(s)
 	if l < n {
-		return fmt.Sprintln(strings.Repeat("0", n-l) + s)
+		return fmt.Sprint(strings.Repeat("0", n-l) + s)
 	} else {
 		return s[l-n : l]
 	}


### PR DESCRIPTION
Issue:
An authentication failure occurred during the encoding of the sequence string in the GenerateAuthDataProcedure function when using the strictHex function.

Troubleshoot:
The failure was traced to the presence of a newline character generated while converting the sequence number to hex. This occurred due to the use of Sprintln in the strictHex function.

Fix:
The issue was resolved by replacing Sprintln with Sprint in the strictHex function.

Supporting Data:
[invalid-sqnStr.zip](https://github.com/user-attachments/files/17114453/invalid-sqnStr.zip)

