### PR TITLE
feat: add UDM metrics counters

### DIFF
--- a/metrics/telemetry.go
+++ b/metrics/telemetry.go
@@ -11,8 +11,56 @@ import (
 	"net/http"
 
 	"github.com/omec-project/udm/logger"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
+
+// UdmStats captures UDM stats
+type UdmStats struct {
+	udmSubscriberDataManagement *prometheus.CounterVec
+	udmUeContextManagement      *prometheus.CounterVec
+	udmUeAuthentication         *prometheus.CounterVec
+}
+
+var udmStats *UdmStats
+
+func initUdmStats() *UdmStats {
+	return &UdmStats{
+		udmSubscriberDataManagement: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "udm_subscriber_data_management",
+			Help: "Counter of total Subscriber Data management queries",
+		}, []string{"query_type", "requested_data_type", "result"}),
+		udmUeContextManagement: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "udm_ue_context_management",
+			Help: "Counter of total UE context management queries",
+		}, []string{"query_type", "requested_data_type", "result"}),
+		udmUeAuthentication: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "udm_ue_authentication",
+			Help: "Counter of total UE authentication queries",
+		}, []string{"query_type", "result"}),
+	}
+}
+
+func (ps *UdmStats) register() error {
+	if err := prometheus.Register(ps.udmSubscriberDataManagement); err != nil {
+		return err
+	}
+	if err := prometheus.Register(ps.udmUeContextManagement); err != nil {
+		return err
+	}
+	if err := prometheus.Register(ps.udmUeAuthentication); err != nil {
+		return err
+	}
+	return nil
+}
+
+func init() {
+	udmStats = initUdmStats()
+
+	if err := udmStats.register(); err != nil {
+		logger.InitLog.Errorln("UDM Stats register failed")
+	}
+}
 
 // InitMetrics initialises UDM metrics
 func InitMetrics() {
@@ -20,4 +68,19 @@ func InitMetrics() {
 	if err := http.ListenAndServe(":8080", nil); err != nil {
 		logger.InitLog.Errorf("Could not open metrics port: %v", err)
 	}
+}
+
+// IncrementUdmSubscriberDataManagementStats increments number of total Subscriber Data management queries
+func IncrementUdmSubscriberDataManagementStats(queryType, requestedDataType, result string) {
+	udmStats.udmSubscriberDataManagement.WithLabelValues(queryType, requestedDataType, result).Inc()
+}
+
+// IncrementUdmUeContextManagementStats increments number of total UE context management queries
+func IncrementUdmUeContextManagementStats(queryType, requestedDataType, result string) {
+	udmStats.udmUeContextManagement.WithLabelValues(queryType, requestedDataType, result).Inc()
+}
+
+// IncrementUdmUeAuthenticationStats increments number of total UE authentication queries
+func IncrementUdmUeAuthenticationStats(queryType, result string) {
+	udmStats.udmUeAuthentication.WithLabelValues(queryType, result).Inc()
 }

--- a/producer/subscriber_data_management.go
+++ b/producer/subscriber_data_management.go
@@ -17,6 +17,7 @@ import (
 	"github.com/omec-project/openapi/models"
 	udm_context "github.com/omec-project/udm/context"
 	"github.com/omec-project/udm/logger"
+	stats "github.com/omec-project/udm/metrics"
 	"github.com/omec-project/udm/util"
 	"github.com/omec-project/util/httpwrapper"
 )
@@ -28,15 +29,18 @@ func HandleGetAmDataRequest(request *httpwrapper.Request) *httpwrapper.Response 
 	supportedFeatures := request.Query.Get("supported-features")
 	response, problemDetails := getAmDataProcedure(supi, plmnID, supportedFeatures)
 	if response != nil {
+		stats.IncrementUdmSubscriberDataManagementStats("get", "am-data", "SUCCESS")
 		// status code is based on SPEC, and option headers
 		return httpwrapper.NewResponse(http.StatusOK, nil, response)
 	} else if problemDetails != nil {
+		stats.IncrementUdmSubscriberDataManagementStats("get", "am-data", "FAILURE")
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 	problemDetails = &models.ProblemDetails{
 		Status: http.StatusForbidden,
 		Cause:  "UNSPECIFIED",
 	}
+	stats.IncrementUdmSubscriberDataManagementStats("get", "am-data", "FAILURE")
 	return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 }
 
@@ -92,15 +96,18 @@ func HandleGetIdTranslationResultRequest(request *httpwrapper.Request) *httpwrap
 	gpsi := request.Params["gpsi"]
 	response, problemDetails := getIdTranslationResultProcedure(gpsi)
 	if response != nil {
+		stats.IncrementUdmSubscriberDataManagementStats("get", "id-translation-result", "SUCCESS")
 		// status code is based on SPEC, and option headers
 		return httpwrapper.NewResponse(http.StatusOK, nil, response)
 	} else if problemDetails != nil {
+		stats.IncrementUdmSubscriberDataManagementStats("get", "id-translation-result", "FAILURE")
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 	problemDetails = &models.ProblemDetails{
 		Status: http.StatusForbidden,
 		Cause:  "UNSPECIFIED",
 	}
+	stats.IncrementUdmSubscriberDataManagementStats("get", "id-translation-result", "FAILURE")
 	return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 }
 
@@ -171,15 +178,18 @@ func HandleGetSupiRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	supportedFeatures := request.Query.Get("supported-features")
 	response, problemDetails := getSupiProcedure(supi, plmnID, dataSetNames, supportedFeatures)
 	if response != nil {
+		stats.IncrementUdmSubscriberDataManagementStats("get", "supi", "SUCCESS")
 		// status code is based on SPEC, and option headers
 		return httpwrapper.NewResponse(http.StatusOK, nil, response)
 	} else if problemDetails != nil {
+		stats.IncrementUdmSubscriberDataManagementStats("get", "supi", "FAILURE")
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 	problemDetails = &models.ProblemDetails{
 		Status: http.StatusForbidden,
 		Cause:  "UNSPECIFIED",
 	}
+	stats.IncrementUdmSubscriberDataManagementStats("get", "supi", "FAILURE")
 	return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 }
 
@@ -428,15 +438,18 @@ func HandleGetSharedDataRequest(request *httpwrapper.Request) *httpwrapper.Respo
 	supportedFeatures := request.Query.Get("supported-features")
 	response, problemDetails := getSharedDataProcedure(sharedDataIds, supportedFeatures)
 	if response != nil {
+		stats.IncrementUdmSubscriberDataManagementStats("get", "shared-data", "SUCCESS")
 		// status code is based on SPEC, and option headers
 		return httpwrapper.NewResponse(http.StatusOK, nil, response)
 	} else if problemDetails != nil {
+		stats.IncrementUdmSubscriberDataManagementStats("get", "shared-data", "FAILURE")
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 	problemDetails = &models.ProblemDetails{
 		Status: http.StatusForbidden,
 		Cause:  "UNSPECIFIED",
 	}
+	stats.IncrementUdmSubscriberDataManagementStats("get", "shared-data", "FAILURE")
 	return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 }
 
@@ -497,15 +510,18 @@ func HandleGetSmDataRequest(request *httpwrapper.Request) *httpwrapper.Response 
 	supportedFeatures := request.Query.Get("supported-features")
 	response, problemDetails := getSmDataProcedure(supi, plmnID, Dnn, Snssai, supportedFeatures)
 	if response != nil {
+		stats.IncrementUdmSubscriberDataManagementStats("get", "sm-data", "SUCCESS")
 		// status code is based on SPEC, and option headers
 		return httpwrapper.NewResponse(http.StatusOK, nil, response)
 	} else if problemDetails != nil {
+		stats.IncrementUdmSubscriberDataManagementStats("get", "sm-data", "FAILURE")
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 	problemDetails = &models.ProblemDetails{
 		Status: http.StatusForbidden,
 		Cause:  "UNSPECIFIED",
 	}
+	stats.IncrementUdmSubscriberDataManagementStats("get", "sm-data", "FAILURE")
 	return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 }
 
@@ -593,15 +609,18 @@ func HandleGetNssaiRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	supportedFeatures := request.Query.Get("supported-features")
 	response, problemDetails := getNssaiProcedure(supi, plmnID, supportedFeatures)
 	if response != nil {
+		stats.IncrementUdmSubscriberDataManagementStats("get", "nssai", "SUCCESS")
 		// status code is based on SPEC, and option headers
 		return httpwrapper.NewResponse(http.StatusOK, nil, response)
 	} else if problemDetails != nil {
+		stats.IncrementUdmSubscriberDataManagementStats("get", "nssai", "FAILURE")
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 	problemDetails = &models.ProblemDetails{
 		Status: http.StatusForbidden,
 		Cause:  "UNSPECIFIED",
 	}
+	stats.IncrementUdmSubscriberDataManagementStats("get", "nssai", "FAILURE")
 	return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 }
 
@@ -662,15 +681,18 @@ func HandleGetSmfSelectDataRequest(request *httpwrapper.Request) *httpwrapper.Re
 	supportedFeatures := request.Query.Get("supported-features")
 	response, problemDetails := getSmfSelectDataProcedure(supi, plmnID, supportedFeatures)
 	if response != nil {
+		stats.IncrementUdmSubscriberDataManagementStats("get", "smf-select-data", "SUCCESS")
 		// status code is based on SPEC, and option headers
 		return httpwrapper.NewResponse(http.StatusOK, nil, response)
 	} else if problemDetails != nil {
+		stats.IncrementUdmSubscriberDataManagementStats("get", "smf-select-data", "FAILURE")
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 	problemDetails = &models.ProblemDetails{
 		Status: http.StatusForbidden,
 		Cause:  "UNSPECIFIED",
 	}
+	stats.IncrementUdmSubscriberDataManagementStats("get", "smf-select-data", "FAILURE")
 	return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 }
 
@@ -730,11 +752,14 @@ func HandleSubscribeToSharedDataRequest(request *httpwrapper.Request) *httpwrapp
 	sdmSubscription := request.Body.(models.SdmSubscription)
 	header, response, problemDetails := subscribeToSharedDataProcedure(&sdmSubscription)
 	if response != nil {
+		stats.IncrementUdmSubscriberDataManagementStats("create", "shared-data-subscriptions", "SUCCESS")
 		// status code is based on SPEC, and option headers
 		return httpwrapper.NewResponse(http.StatusCreated, header, response)
 	} else if problemDetails != nil {
+		stats.IncrementUdmSubscriberDataManagementStats("create", "shared-data-subscriptions", "FAILURE")
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	} else {
+		stats.IncrementUdmSubscriberDataManagementStats("create", "shared-data-subscriptions", "FAILURE")
 		return httpwrapper.NewResponse(http.StatusNotFound, nil, nil)
 	}
 }
@@ -796,11 +821,14 @@ func HandleSubscribeRequest(request *httpwrapper.Request) *httpwrapper.Response 
 	supi := request.Params["supi"]
 	header, response, problemDetails := subscribeProcedure(&sdmSubscription, supi)
 	if response != nil {
+		stats.IncrementUdmSubscriberDataManagementStats("create", "sdm-subscriptions", "SUCCESS")
 		// status code is based on SPEC, and option headers
 		return httpwrapper.NewResponse(http.StatusCreated, header, response)
 	} else if problemDetails != nil {
+		stats.IncrementUdmSubscriberDataManagementStats("create", "sdm-subscriptions", "FAILURE")
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	} else {
+		stats.IncrementUdmSubscriberDataManagementStats("create", "sdm-subscriptions", "FAILURE")
 		return httpwrapper.NewResponse(http.StatusNotFound, nil, nil)
 	}
 }
@@ -865,9 +893,10 @@ func HandleUnsubscribeForSharedDataRequest(request *httpwrapper.Request) *httpwr
 	subscriptionID := request.Params["subscriptionId"]
 	problemDetails := unsubscribeForSharedDataProcedure(subscriptionID)
 	if problemDetails != nil {
+		stats.IncrementUdmSubscriberDataManagementStats("delete", "shared-data-subscriptions", "FAILURE")
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
-
+	stats.IncrementUdmSubscriberDataManagementStats("delete", "shared-data-subscriptions", "SUCCESS")
 	return httpwrapper.NewResponse(http.StatusNoContent, nil, nil)
 }
 
@@ -915,9 +944,10 @@ func HandleUnsubscribeRequest(request *httpwrapper.Request) *httpwrapper.Respons
 	subscriptionID := request.Params["subscriptionId"]
 	problemDetails := unsubscribeProcedure(supi, subscriptionID)
 	if problemDetails != nil {
+		stats.IncrementUdmSubscriberDataManagementStats("delete", "sdm-subscriptions", "FAILURE")
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
-
+	stats.IncrementUdmSubscriberDataManagementStats("delete", "sdm-subscriptions", "SUCCESS")
 	return httpwrapper.NewResponse(http.StatusNoContent, nil, nil)
 }
 
@@ -967,15 +997,18 @@ func HandleModifyRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	subscriptionID := request.Params["subscriptionId"]
 	response, problemDetails := modifyProcedure(&sdmSubsModification, supi, subscriptionID)
 	if response != nil {
+		stats.IncrementUdmSubscriberDataManagementStats("update", "sdm-subscriptions", "SUCCESS")
 		// status code is based on SPEC, and option headers
 		return httpwrapper.NewResponse(http.StatusOK, nil, response)
 	} else if problemDetails != nil {
+		stats.IncrementUdmSubscriberDataManagementStats("update", "sdm-subscriptions", "FAILURE")
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 	problemDetails = &models.ProblemDetails{
 		Status: http.StatusForbidden,
 		Cause:  "UNSPECIFIED",
 	}
+	stats.IncrementUdmSubscriberDataManagementStats("update", "sdm-subscriptions", "FAILURE")
 	return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 }
 
@@ -1032,15 +1065,18 @@ func HandleModifyForSharedDataRequest(request *httpwrapper.Request) *httpwrapper
 	subscriptionID := request.Params["subscriptionId"]
 	response, problemDetails := modifyForSharedDataProcedure(&sdmSubsModification, supi, subscriptionID)
 	if response != nil {
+		stats.IncrementUdmSubscriberDataManagementStats("update", "shared-data-subscriptions", "SUCCESS")
 		// status code is based on SPEC, and option headers
 		return httpwrapper.NewResponse(http.StatusOK, nil, response)
 	} else if problemDetails != nil {
+		stats.IncrementUdmSubscriberDataManagementStats("update", "shared-data-subscriptions", "FAILURE")
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 	problemDetails = &models.ProblemDetails{
 		Status: http.StatusForbidden,
 		Cause:  "UNSPECIFIED",
 	}
+	stats.IncrementUdmSubscriberDataManagementStats("update", "shared-data-subscriptions", "FAILURE")
 	return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 }
 
@@ -1098,15 +1134,18 @@ func HandleGetTraceDataRequest(request *httpwrapper.Request) *httpwrapper.Respon
 	plmnID := request.Query.Get("plmn-id")
 	response, problemDetails := getTraceDataProcedure(supi, plmnID)
 	if response != nil {
+		stats.IncrementUdmSubscriberDataManagementStats("get", "trace-data", "SUCCESS")
 		// status code is based on SPEC, and option headers
 		return httpwrapper.NewResponse(http.StatusOK, nil, response)
 	} else if problemDetails != nil {
+		stats.IncrementUdmSubscriberDataManagementStats("get", "trace-data", "FAILURE")
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 	problemDetails = &models.ProblemDetails{
 		Status: http.StatusForbidden,
 		Cause:  "UNSPECIFIED",
 	}
+	stats.IncrementUdmSubscriberDataManagementStats("get", "trace-data", "FAILURE")
 	return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 }
 
@@ -1168,15 +1207,18 @@ func HandleGetUeContextInSmfDataRequest(request *httpwrapper.Request) *httpwrapp
 	supportedFeatures := request.Query.Get("supported-features")
 	response, problemDetails := getUeContextInSmfDataProcedure(supi, supportedFeatures)
 	if response != nil {
+		stats.IncrementUdmSubscriberDataManagementStats("get", "ue-context-in-smf-data", "SUCCESS")
 		// status code is based on SPEC, and option headers
 		return httpwrapper.NewResponse(http.StatusOK, nil, response)
 	} else if problemDetails != nil {
+		stats.IncrementUdmSubscriberDataManagementStats("get", "ue-context-in-smf-data", "FAILURE")
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 	problemDetails = &models.ProblemDetails{
 		Status: http.StatusForbidden,
 		Cause:  "UNSPECIFIED",
 	}
+	stats.IncrementUdmSubscriberDataManagementStats("get", "ue-context-in-smf-data", "FAILURE")
 	return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 }
 

--- a/producer/ue_context_management.go
+++ b/producer/ue_context_management.go
@@ -19,6 +19,7 @@ import (
 	"github.com/omec-project/udm/consumer"
 	udmContext "github.com/omec-project/udm/context"
 	"github.com/omec-project/udm/logger"
+	stats "github.com/omec-project/udm/metrics"
 	"github.com/omec-project/udm/producer/callback"
 	"github.com/omec-project/udm/util"
 	"github.com/omec-project/util/httpwrapper"
@@ -79,15 +80,18 @@ func HandleGetAmf3gppAccessRequest(request *httpwrapper.Request) *httpwrapper.Re
 	supportedFeatures := request.Query.Get("supported-features")
 	response, problemDetails := GetAmf3gppAccessProcedure(ueID, supportedFeatures)
 	if response != nil {
+		stats.IncrementUdmUeContextManagementStats("get", "amf-3gpp-access", "SUCCESS")
 		// status code is based on SPEC, and option headers
 		return httpwrapper.NewResponse(http.StatusOK, nil, response)
 	} else if problemDetails != nil {
+		stats.IncrementUdmUeContextManagementStats("get", "amf-3gpp-access", "FAILURE")
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 	problemDetails = &models.ProblemDetails{
 		Status: http.StatusForbidden,
 		Cause:  "UNSPECIFIED",
 	}
+	stats.IncrementUdmUeContextManagementStats("get", "amf-3gpp-access", "FAILURE")
 	return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 }
 
@@ -129,15 +133,18 @@ func HandleGetAmfNon3gppAccessRequest(request *httpwrapper.Request) *httpwrapper
 	queryAmfContextNon3gppParamOpts.SupportedFeatures = optional.NewString(supportedFeatures)
 	response, problemDetails := GetAmfNon3gppAccessProcedure(queryAmfContextNon3gppParamOpts, ueId)
 	if response != nil {
+		stats.IncrementUdmUeContextManagementStats("get", "amf-non-3gpp-access", "SUCCESS")
 		// status code is based on SPEC, and option headers
 		return httpwrapper.NewResponse(http.StatusOK, nil, response)
 	} else if problemDetails != nil {
+		stats.IncrementUdmUeContextManagementStats("get", "amf-non-3gpp-access", "FAILURE")
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 	problemDetails = &models.ProblemDetails{
 		Status: http.StatusForbidden,
 		Cause:  "UNSPECIFIED",
 	}
+	stats.IncrementUdmUeContextManagementStats("get", "amf-non-3gpp-access", "FAILURE")
 	return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 }
 
@@ -176,11 +183,14 @@ func HandleRegistrationAmf3gppAccessRequest(request *httpwrapper.Request) *httpw
 	logger.UecmLog.Info("UEID: ", ueID)
 	header, response, problemDetails := RegistrationAmf3gppAccessProcedure(registerRequest, ueID)
 	if response != nil {
+		stats.IncrementUdmUeContextManagementStats("create", "amf-3gpp-access", "SUCCESS")
 		// status code is based on SPEC, and option headers
 		return httpwrapper.NewResponse(http.StatusCreated, header, response)
 	} else if problemDetails != nil {
+		stats.IncrementUdmUeContextManagementStats("create", "amf-3gpp-access", "FAILURE")
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	} else {
+		stats.IncrementUdmUeContextManagementStats("create", "amf-3gpp-access", "SUCCESS")
 		return httpwrapper.NewResponse(http.StatusNoContent, nil, nil)
 	}
 }
@@ -249,11 +259,14 @@ func HandleRegisterAmfNon3gppAccessRequest(request *httpwrapper.Request) *httpwr
 	ueID := request.Params["ueId"]
 	header, response, problemDetails := RegisterAmfNon3gppAccessProcedure(registerRequest, ueID)
 	if response != nil {
+		stats.IncrementUdmUeContextManagementStats("create", "amf-non-3gpp-access", "SUCCESS")
 		// status code is based on SPEC, and option headers
 		return httpwrapper.NewResponse(http.StatusCreated, header, response)
 	} else if problemDetails != nil {
+		stats.IncrementUdmUeContextManagementStats("create", "amf-non-3gpp-access", "FAILURE")
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	} else {
+		stats.IncrementUdmUeContextManagementStats("create", "amf-non-3gpp-access", "SUCCESS")
 		return httpwrapper.NewResponse(http.StatusNoContent, nil, nil)
 	}
 }
@@ -319,8 +332,10 @@ func HandleUpdateAmf3gppAccessRequest(request *httpwrapper.Request) *httpwrapper
 	ueID := request.Params["ueId"]
 	problemDetails := UpdateAmf3gppAccessProcedure(amf3GppAccessRegistrationModification, ueID)
 	if problemDetails != nil {
+		stats.IncrementUdmUeContextManagementStats("update", "amf-3gpp-access", "FAILURE")
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	} else {
+		stats.IncrementUdmUeContextManagementStats("update", "amf-3gpp-access", "SUCCESS")
 		return httpwrapper.NewResponse(http.StatusNoContent, nil, nil)
 	}
 }
@@ -424,8 +439,10 @@ func HandleUpdateAmfNon3gppAccessRequest(request *httpwrapper.Request) *httpwrap
 	ueID := request.Params["ueId"]
 	problemDetails := UpdateAmfNon3gppAccessProcedure(requestMSG, ueID)
 	if problemDetails != nil {
+		stats.IncrementUdmUeContextManagementStats("update", "amf-non-3gpp-access", "FAILURE")
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	} else {
+		stats.IncrementUdmUeContextManagementStats("update", "amf-non-3gpp-access", "SUCCESS")
 		return httpwrapper.NewResponse(http.StatusNoContent, nil, nil)
 	}
 }
@@ -527,8 +544,10 @@ func HandleDeregistrationSmfRegistrations(request *httpwrapper.Request) *httpwra
 	pduSessionID := request.Params["pduSessionId"]
 	problemDetails := DeregistrationSmfRegistrationsProcedure(ueID, pduSessionID)
 	if problemDetails != nil {
+		stats.IncrementUdmUeContextManagementStats("delete", "smf-registrations", "FAILURE")
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	} else {
+		stats.IncrementUdmUeContextManagementStats("delete", "smf-registrations", "SUCCESS")
 		return httpwrapper.NewResponse(http.StatusNoContent, nil, nil)
 	}
 }
@@ -565,11 +584,14 @@ func HandleRegistrationSmfRegistrationsRequest(request *httpwrapper.Request) *ht
 	pduSessionID := request.Params["pduSessionId"]
 	header, response, problemDetails := RegistrationSmfRegistrationsProcedure(&registerRequest, ueID, pduSessionID)
 	if response != nil {
+		stats.IncrementUdmUeContextManagementStats("create", "smf-registrations", "SUCCESS")
 		// status code is based on SPEC, and option headers
 		return httpwrapper.NewResponse(http.StatusCreated, header, response)
 	} else if problemDetails != nil {
+		stats.IncrementUdmUeContextManagementStats("create", "smf-registrations", "FAILURE")
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	} else {
+		stats.IncrementUdmUeContextManagementStats("create", "smf-registrations", "SUCCESS")
 		// all nil
 		return httpwrapper.NewResponse(http.StatusNoContent, nil, nil)
 	}


### PR DESCRIPTION
This PR adds three new 5G specific metrics, `udm_subscriber_data_management`, `udm_ue_context_management` and `udm_ue_authentication` to exported metrics via Prometheus.
The scope of the metrics is the following:
* `udm_subscriber_data_management`: this metric counts the total number of Subscriber Data management queries to UDM; the metric stores the query type (`create`, `get`, `update`, `delete`), the requested data and the result (`SUCCESS`, `FAILURE`);
* `udm_ue_context_management`: this metric counts the total number of UE context management queries to UDM; the metric stores the query type (`create`, `get`, `update`, `delete`), the requested data and the result (`SUCCESS`, `FAILURE`);
* `udm_ue_authentication`: this metric counts the total UE authentication queries to PCF; the metric stores the query type (`create`, `get`, `update`, `delete`) and the result (`SUCCESS`, `FAILURE`).