### PR TITLE
fix: Increase SQNMax number

### DIFF
--- a/producer/generate_auth_data.go
+++ b/producer/generate_auth_data.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	SqnMAx    int64 = 0x7FFFFFFFFFF
+	SqnMAx    int64 = 0xFFFFFFFFFFFF
 	ind       int64 = 32
 	keyStrLen int   = 32
 	opStrLen  int   = 32


### PR DESCRIPTION
According to ` 3GPP TS 35.208` SQN is a 48 bit random number in HEX format. According to this definition all the HEX numbers lower than or equal to 0xFFFFFFFFFFFF ( equals to 281474976710655 as Decimal) should be acceptable.  However, in UDM, SQN is limited with 0x7FFFFFFFFF (equals to Decimal 8796093022207). 
Because of this, some SQN values provided in the defined range causes UE authentication failures. 
For example, test set 4, test set 18 and test set 19 which are provided in 3GPP TS 35.208 version 15.0.0 Release 15 is not accepted in the current version of UDM.