### PR TITLE
fix: Trims SQN string passed to strictHex to make sure it doesn't have any non-printable characters

### DIFF
--- a/producer/generate_auth_data.go
+++ b/producer/generate_auth_data.go
@@ -72,6 +72,7 @@ func aucSQN(opc, k, auts, rand []byte) ([]byte, []byte) {
 }
 
 func strictHex(s string, n int) string {
+    s = strings.TrimSpace(s)
 	l := len(s)
 	if l < n {
 		return fmt.Sprint(strings.Repeat("0", n-l) + s)


### PR DESCRIPTION
The `strictHex` method is used to normalize SQN hex - it needs to be exactly 12-characters long in order to produce a 6-element byte slice. 
In some cases, the SQN hex returned by the UDR client contains a new line at the end of the valid SQN hex string. As a result, `strictHex` assumes that the string length is 13 characters and "normalizes" it by cutting of the first digit. This produces an invalid, 11-char long output, which causes authentication error: `err encoding/hex: invalid byte: U+000A`. 
This PR addresses this problem by trimming all non-printable chars off the input string before `strictHex` assesses the length of the input.

Some logs:
Initial state, sequenceNumber assigned to the subscriber is `0001863958fe`, UE authenticates for the first time:
```
2024-10-24T11:16:12.611Z [udm] 2024-10-24T11:16:12Z [TRAC][UDM][UEAU] authSubs.SequenceNumber before strictHex 0001863958fe (/root/parts/udm/build/producer/generate_auth_data.go:314 github.com/omec-project/udm/producer.GenerateAuthDataProcedure)
2024-10-24T11:16:12.611Z [udm] 2024-10-24T11:16:12Z [TRAC][UDM][UEAU] strictHex input: 0001863958fe (/root/parts/udm/build/producer/generate_auth_data.go:80 github.com/omec-project/udm/producer.strictHex)
2024-10-24T11:16:12.611Z [udm] 2024-10-24T11:16:12Z [TRAC][UDM][UEAU] strictHex input len: 12 (/root/parts/udm/build/producer/generate_auth_data.go:82 github.com/omec-project/udm/producer.strictHex)
2024-10-24T11:16:12.611Z [udm] 2024-10-24T11:16:12Z [TRAC][UDM][UEAU] strictHex input split: [0 0 0 1 8 6 3 9 5 8 f e] (/root/parts/udm/build/producer/generate_auth_data.go:83 github.com/omec-project/udm/producer.strictHex)
2024-10-24T11:16:12.611Z [udm] 2024-10-24T11:16:12Z [TRAC][UDM][UEAU] strictHex else: 0001863958fe (/root/parts/udm/build/producer/generate_auth_data.go:88 github.com/omec-project/udm/producer.strictHex)
2024-10-24T11:16:12.611Z [udm] 2024-10-24T11:16:12Z [TRAC][UDM][UEAU] sqnStr 0001863958fe (/root/parts/udm/build/producer/generate_auth_data.go:316 github.com/omec-project/udm/producer.GenerateAuthDataProcedure)
2024-10-24T11:16:12.611Z [udm] 2024-10-24T11:16:12Z [TRAC][UDM][UEAU] sqn [0 1 134 57 88 254] (/root/parts/udm/build/producer/generate_auth_data.go:329 github.com/omec-project/udm/producer.GenerateAuthDataProcedure)
2024-10-24T11:16:12.611Z [udm] 2024-10-24T11:16:12Z [TRAC][UDM][UEAU] strictHex input: 1863958ff (/root/parts/udm/build/producer/generate_auth_data.go:80 github.com/omec-project/udm/producer.strictHex)
2024-10-24T11:16:12.611Z [udm] 2024-10-24T11:16:12Z [TRAC][UDM][UEAU] strictHex input len: 9 (/root/parts/udm/build/producer/generate_auth_data.go:82 github.com/omec-project/udm/producer.strictHex)
2024-10-24T11:16:12.611Z [udm] 2024-10-24T11:16:12Z [TRAC][UDM][UEAU] strictHex input split: [1 8 6 3 9 5 8 f f] (/root/parts/udm/build/producer/generate_auth_data.go:83 github.com/omec-project/udm/producer.strictHex)
2024-10-24T11:16:12.611Z [udm] 2024-10-24T11:16:12Z [TRAC][UDM][UEAU] strictHex l < n: 0001863958ff (/root/parts/udm/build/producer/generate_auth_data.go:85 github.com/omec-project/udm/producer.strictHex)
```
Authentication was successful, the SQN has been increased. So far, so good.
**Now the gNB fails (CU and DU are restarted) and the UE needs to reattach:**
```
2024-10-24T11:30:28.233Z [udm] 2024-10-24T11:30:28Z [TRAC][UDM][UEAU] authSubs.SequenceNumber before strictHex 0001863958ff (/root/parts/udm/build/producer/generate_auth_data.go:314 github.com/omec-project/udm/producer.GenerateAuthDataProcedure)
2024-10-24T11:30:28.233Z [udm] 2024-10-24T11:30:28Z [TRAC][UDM][UEAU] strictHex input: 0001863958ff (/root/parts/udm/build/producer/generate_auth_data.go:80 github.com/omec-project/udm/producer.strictHex)
2024-10-24T11:30:28.233Z [udm] 2024-10-24T11:30:28Z [TRAC][UDM][UEAU] strictHex input len: 13 (/root/parts/udm/build/producer/generate_auth_data.go:82 github.com/omec-project/udm/producer.strictHex)
2024-10-24T11:30:28.233Z [udm] 2024-10-24T11:30:28Z [TRAC][UDM][UEAU] strictHex input split: [0 0 0 1 8 6 3 9 5 8 f f 
2024-10-24T11:30:28.233Z [udm] ] (/root/parts/udm/build/producer/generate_auth_data.go:83 github.com/omec-project/udm/producer.strictHex)
2024-10-24T11:30:28.233Z [udm] 2024-10-24T11:30:28Z [TRAC][UDM][UEAU] strictHex else: 001863958ff (/root/parts/udm/build/producer/generate_auth_data.go:88 github.com/omec-project/udm/producer.strictHex)
2024-10-24T11:30:28.233Z [udm] 2024-10-24T11:30:28Z [TRAC][UDM][UEAU] sqnStr 001863958ff (/root/parts/udm/build/producer/generate_auth_data.go:316 github.com/omec-project/udm/producer.GenerateAuthDataProcedure)
2024-10-24T11:30:28.233Z [udm] 2024-10-24T11:30:28Z [ERRO][UDM][UEAU] err encoding/hex: invalid byte: U+000A (/root/parts/udm/build/producer/generate_auth_data.go:325 github.com/omec-project/udm/producer.GenerateAuthDataProcedure)
```
 UDM fetches the SQN hex from UDR: `0001863958ff`, but because it's returned with a new line at the end, `strictHex` thinks it's 13-chars long. So it cuts one character and returns `001863958ff`. New line gets trimmed as well, because `strictHex` creates a slice. New SQN hex is 11-chars long, so it can't produce a 6-element byte slice. As a result we get `err encoding/hex: invalid byte: U+000A`.

After applying a fix from this PR we get:
```
2024-10-24T13:36:02.526Z [udm] 2024-10-24T13:36:02Z [TRAC][UDM][UEAU] authSubs.SequenceNumber before strictHex 0001863958ff (/root/parts/udm/build/producer/generate_auth_data.go:317 github.com/omec-project/udm/producer.GenerateAuthDataProcedure)
2024-10-24T13:36:02.526Z [udm] 2024-10-24T13:36:02Z [TRAC][UDM][UEAU] strictHex input: 0001863958ff (/root/parts/udm/build/producer/generate_auth_data.go:80 github.com/omec-project/udm/producer.strictHex)
2024-10-24T13:36:02.526Z [udm] 2024-10-24T13:36:02Z [TRAC][UDM][UEAU] strictHex input len: 13 (/root/parts/udm/build/producer/generate_auth_data.go:82 github.com/omec-project/udm/producer.strictHex)
2024-10-24T13:36:02.526Z [udm] 2024-10-24T13:36:02Z [TRAC][UDM][UEAU] strictHex input len after trimming: 12 (/root/parts/udm/build/producer/generate_auth_data.go:85 github.com/omec-project/udm/producer.strictHex)
2024-10-24T13:36:02.526Z [udm] 2024-10-24T13:36:02Z [TRAC][UDM][UEAU] strictHex input split: [0 0 0 1 8 6 3 9 5 8 f f] (/root/parts/udm/build/producer/generate_auth_data.go:86 github.com/omec-project/udm/producer.strictHex)
```
