### PR TITLE
chore: enable static check and govet in the ci

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,14 +21,13 @@ linters:
     - goconst
     - godox
     - gomodguard
+    - govet
     - misspell
     - noctx
     - predeclared
+    - staticcheck
     - unconvert
     - whitespace
-  disable:
-    - govet
-    - staticcheck
   settings:
     errcheck:
       check-type-assertions: false
@@ -62,6 +61,8 @@ linters:
         - XXX
     govet:
       enable-all: true
+      disable:
+        - fieldalignment
       settings:
         printf:
           funcs:

--- a/producer/subscriber_data_management.go
+++ b/producer/subscriber_data_management.go
@@ -792,20 +792,21 @@ func subscribeToSharedDataProcedure(sdmSubscription *models.SdmSubscription) (
 		}
 	}()
 
-	if res.StatusCode == http.StatusCreated {
+	switch res.StatusCode {
+	case http.StatusCreated:
 		header = make(http.Header)
 		udm_context.UDM_Self().CreateSubstoNotifSharedData(sdmSubscriptionResp.SubscriptionId, &sdmSubscriptionResp)
 		reourceUri := udm_context.UDM_Self().GetSDMUri() + "//shared-data-subscriptions/" + sdmSubscriptionResp.SubscriptionId
 		header.Set("Location", reourceUri)
 		return header, &sdmSubscriptionResp, nil
-	} else if res.StatusCode == http.StatusNotFound {
+	case http.StatusNotFound:
 		problemDetails = &models.ProblemDetails{
 			Status: http.StatusNotFound,
 			Cause:  "DATA_NOT_FOUND",
 		}
 
 		return nil, nil, problemDetails
-	} else {
+	default:
 		problemDetails = &models.ProblemDetails{
 			Status: http.StatusNotImplemented,
 			Cause:  "UNSUPPORTED_RESOURCE_URI",
@@ -864,7 +865,8 @@ func subscribeProcedure(sdmSubscription *models.SdmSubscription, supi string) (
 		}
 	}()
 
-	if res.StatusCode == http.StatusCreated {
+	switch res.StatusCode {
+	case http.StatusCreated:
 		header = make(http.Header)
 		udmUe, _ := udm_context.UDM_Self().UdmUeFindBySupi(supi)
 		if udmUe == nil {
@@ -873,13 +875,13 @@ func subscribeProcedure(sdmSubscription *models.SdmSubscription, supi string) (
 		udmUe.CreateSubscriptiontoNotifChange(sdmSubscriptionResp.SubscriptionId, &sdmSubscriptionResp)
 		header.Set("Location", udmUe.GetLocationURI2(udm_context.LocationUriSdmSubscription, supi))
 		return header, &sdmSubscriptionResp, nil
-	} else if res.StatusCode == http.StatusNotFound {
+	case http.StatusNotFound:
 		problemDetails = &models.ProblemDetails{
 			Status: http.StatusNotFound,
 			Cause:  "DATA_NOT_FOUND",
 		}
 		return nil, nil, problemDetails
-	} else {
+	default:
 		problemDetails = &models.ProblemDetails{
 			Status: http.StatusNotImplemented,
 			Cause:  "UNSUPPORTED_RESOURCE_URI",

--- a/service/init.go
+++ b/service/init.go
@@ -255,10 +255,14 @@ func (udm *UDM) Start() {
 	}
 
 	serverScheme := factory.UdmConfig.Configuration.Sbi.Scheme
-	if serverScheme == "http" {
+	switch serverScheme {
+	case "http":
 		err = server.ListenAndServe()
-	} else if serverScheme == "https" {
+	case "https":
 		err = server.ListenAndServeTLS(sbi.Tls.Pem, sbi.Tls.Key)
+	default:
+		logger.InitLog.Fatalf("HTTP server setup failed: invalid server scheme %+v", serverScheme)
+		return
 	}
 
 	if err != nil {
@@ -335,7 +339,7 @@ func (udm *UDM) updateConfig(commChannel chan *protos.NetworkSliceResponse) bool
 			logger.GrpcLog.Infoln("network Slice Name", ns.Name)
 			if ns.Site != nil {
 				temp := factory.PlmnSupportItem{}
-				var found bool = false
+				found := false
 				logger.GrpcLog.Infoln("network Slice has site name present ")
 				site := ns.Site
 				logger.GrpcLog.Infoln("site name", site.SiteName)


### PR DESCRIPTION
this PR enables `staticcheck` and `govet` in the CI

- fix a variable declaration
- replace if with switch

govet's `fieldaligment` remains disabled