### PR TITLE
refactor: replace duplicated string literals with constants in subscriberdatamanagement package.

### DIFF
--- a/subscriberdatamanagement/api_subscription_creation.go
+++ b/subscriberdatamanagement/api_subscription_creation.go
@@ -47,7 +47,7 @@ func HTTPSubscribe(c *gin.Context) {
 	}
 
 	// step 2: convert requestBody to openapi models
-	err = openapi.Decode(&sdmSubscriptionReq, requestBody, "application/json")
+	err = openapi.Decode(&sdmSubscriptionReq, requestBody, contentTypeJson)
 	if err != nil {
 		problemDetail := "[Request Body] " + err.Error()
 		rsp := utils.ProblemDetailsMalformedRequestSyntax(problemDetail)
@@ -64,12 +64,12 @@ func HTTPSubscribe(c *gin.Context) {
 	for key, val := range rsp.Header { // header response is optional
 		c.Header(key, val[0])
 	}
-	responseBody, err := openapi.SetBody(rsp.Body, "application/json")
+	responseBody, err := openapi.SetBody(rsp.Body, contentTypeJson)
 	if err != nil {
 		logger.SdmLog.Errorln(err)
 		problemDetails := utils.ProblemDetailsSystemFailure(err.Error())
 		c.JSON(http.StatusInternalServerError, problemDetails)
 	} else {
-		c.Data(rsp.Status, "application/json", responseBody.Bytes())
+		c.Data(rsp.Status, contentTypeJson, responseBody.Bytes())
 	}
 }

--- a/subscriberdatamanagement/api_subscription_creation_for_shared_data.go
+++ b/subscriberdatamanagement/api_subscription_creation_for_shared_data.go
@@ -31,6 +31,8 @@ import (
 	"github.com/omec-project/util/httpwrapper"
 )
 
+const contentTypeJson = "application/json"
+
 // Post /shared-data-subscriptions
 // subscribe to notifications for shared data
 func HTTPSubscribeToSharedData(c *gin.Context) {
@@ -46,7 +48,7 @@ func HTTPSubscribeToSharedData(c *gin.Context) {
 	}
 
 	// step 2: convert requestBody to openapi models
-	err = openapi.Decode(&sharedDataSubsReq, requestBody, "application/json")
+	err = openapi.Decode(&sharedDataSubsReq, requestBody, contentTypeJson)
 	if err != nil {
 		problemDetail := "[Request Body] " + err.Error()
 		rsp := utils.ProblemDetailsMalformedRequestSyntax(problemDetail)
@@ -61,12 +63,12 @@ func HTTPSubscribeToSharedData(c *gin.Context) {
 	for key, val := range rsp.Header { // header response is optional
 		c.Header(key, val[0])
 	}
-	responseBody, err := openapi.SetBody(rsp.Body, "application/json")
+	responseBody, err := openapi.SetBody(rsp.Body, contentTypeJson)
 	if err != nil {
 		logger.SdmLog.Errorln(err)
 		problemDetails := utils.ProblemDetailsSystemFailure(err.Error())
 		c.JSON(http.StatusInternalServerError, problemDetails)
 	} else {
-		c.Data(rsp.Status, "application/json", responseBody.Bytes())
+		c.Data(rsp.Status, contentTypeJson, responseBody.Bytes())
 	}
 }

--- a/subscriberdatamanagement/api_subscription_creation_for_shared_data.go
+++ b/subscriberdatamanagement/api_subscription_creation_for_shared_data.go
@@ -31,8 +31,6 @@ import (
 	"github.com/omec-project/util/httpwrapper"
 )
 
-const contentTypeJson = "application/json"
-
 // Post /shared-data-subscriptions
 // subscribe to notifications for shared data
 func HTTPSubscribeToSharedData(c *gin.Context) {

--- a/subscriberdatamanagement/api_subscription_modification.go
+++ b/subscriberdatamanagement/api_subscription_modification.go
@@ -46,7 +46,7 @@ func HTTPModify(c *gin.Context) {
 	}
 
 	// step 2: convert requestBody to openapi models
-	err = openapi.Decode(&sdmSubsModificationReq, requestBody, "application/json")
+	err = openapi.Decode(&sdmSubsModificationReq, requestBody, contentTypeJson)
 	if err != nil {
 		problemDetail := "[Request Body] " + err.Error()
 		rsp := utils.ProblemDetailsMalformedRequestSyntax(problemDetail)
@@ -60,13 +60,13 @@ func HTTPModify(c *gin.Context) {
 	req.Params["subscriptionId"] = c.Params.ByName("subscriptionId")
 
 	rsp := producer.HandleModifyRequest(req)
-	responseBody, err := openapi.SetBody(rsp.Body, "application/json")
+	responseBody, err := openapi.SetBody(rsp.Body, contentTypeJson)
 	if err != nil {
 		logger.SdmLog.Errorln(err)
 		problemDetails := utils.ProblemDetailsSystemFailure(err.Error())
 		c.JSON(http.StatusInternalServerError, problemDetails)
 	} else {
-		c.Data(rsp.Status, "application/json", responseBody.Bytes())
+		c.Data(rsp.Status, contentTypeJson, responseBody.Bytes())
 	}
 }
 
@@ -85,7 +85,7 @@ func HTTPModifySharedDataSubs(c *gin.Context) {
 	}
 
 	// step 2: convert requestBody to openapi models
-	err = openapi.Decode(&sharedDataSubscriptions, requestBody, "application/json")
+	err = openapi.Decode(&sharedDataSubscriptions, requestBody, contentTypeJson)
 	if err != nil {
 		problemDetail := "[Request Body] " + err.Error()
 		rsp := utils.ProblemDetailsMalformedRequestSyntax(problemDetail)
@@ -99,12 +99,12 @@ func HTTPModifySharedDataSubs(c *gin.Context) {
 
 	rsp := producer.HandleModifyForSharedDataRequest(req)
 
-	responseBody, err := openapi.SetBody(rsp.Body, "application/json")
+	responseBody, err := openapi.SetBody(rsp.Body, contentTypeJson)
 	if err != nil {
 		logger.SdmLog.Errorln(err)
 		problemDetails := utils.ProblemDetailsSystemFailure(err.Error())
 		c.JSON(http.StatusInternalServerError, problemDetails)
 	} else {
-		c.Data(rsp.Status, "application/json", responseBody.Bytes())
+		c.Data(rsp.Status, contentTypeJson, responseBody.Bytes())
 	}
 }

--- a/subscriberdatamanagement/routers.go
+++ b/subscriberdatamanagement/routers.go
@@ -29,6 +29,8 @@ import (
 	utilLogger "github.com/omec-project/util/logger"
 )
 
+const contentTypeJson = "application/json"
+
 // Route is the information for every URI.
 type Route struct {
 	// Name is the name of this Route.


### PR DESCRIPTION
**Description**

This PR refactors the subscriberdatamanagement package to address code quality issues by replacing duplicated string literals with constants across several files. Hardcoded, duplicate strings increase maintenance overhead and the likelihood of introducing typographical errors during future updates.

**Scope of Changes**

Constants were introduced to replace duplicated strings in:
-  subscriberdatamanagement/api_subscription_creation.go
-  subscriberdatamanagement/api_subscription_creation_for_shared_data.go
-  subscriberdatamanagement/api_subscription_modification.go