### PR TITLE
refactor: replace duplicated string literals with constants in uecontextmanagement package.

### DIFF
--- a/uecontextmanagement/api_amf_registration_for3_gpp_access.go
+++ b/uecontextmanagement/api_amf_registration_for3_gpp_access.go
@@ -46,7 +46,7 @@ func HTTPCall3GppRegistration(c *gin.Context) {
 	}
 
 	// step 2: convert requestBody to openapi models
-	err = openapi.Decode(&amf3GppAccessRegistration, requestBody, "application/json")
+	err = openapi.Decode(&amf3GppAccessRegistration, requestBody, contentTypeJson)
 	if err != nil {
 		problemDetail := "[Request Body] " + err.Error()
 		rsp := utils.ProblemDetailsMalformedRequestSyntax(problemDetail)
@@ -64,12 +64,12 @@ func HTTPCall3GppRegistration(c *gin.Context) {
 	for key, val := range rsp.Header { // header response is optional
 		c.Header(key, val[0])
 	}
-	responseBody, err := openapi.SetBody(rsp.Body, "application/json")
+	responseBody, err := openapi.SetBody(rsp.Body, contentTypeJson)
 	if err != nil {
 		logger.UecmLog.Errorln(err)
 		problemDetails := utils.ProblemDetailsSystemFailure(err.Error())
 		c.JSON(http.StatusInternalServerError, problemDetails)
 	} else {
-		c.Data(rsp.Status, "application/json", responseBody.Bytes())
+		c.Data(rsp.Status, contentTypeJson, responseBody.Bytes())
 	}
 }

--- a/uecontextmanagement/api_amf_registration_for_non3_gpp_access.go
+++ b/uecontextmanagement/api_amf_registration_for_non3_gpp_access.go
@@ -31,6 +31,8 @@ import (
 	"github.com/omec-project/util/httpwrapper"
 )
 
+const contentTypeJson = "application/json"
+
 // Put /:ueId/registrations/amf-non-3gpp-access
 // register as AMF for non-3GPP access
 func HTTPNon3GppRegistration(c *gin.Context) {
@@ -47,7 +49,7 @@ func HTTPNon3GppRegistration(c *gin.Context) {
 	}
 
 	// step 2: convert requestBody to openapi models
-	err = openapi.Decode(&amfNon3GppAccessRegistration, requestBody, "application/json")
+	err = openapi.Decode(&amfNon3GppAccessRegistration, requestBody, contentTypeJson)
 	if err != nil {
 		problemDetail := "[Request Body] " + err.Error()
 		rsp := utils.ProblemDetailsMalformedRequestSyntax(problemDetail)
@@ -64,12 +66,12 @@ func HTTPNon3GppRegistration(c *gin.Context) {
 	for key, val := range rsp.Header { // header response is optional
 		c.Header(key, val[0])
 	}
-	responseBody, err := openapi.SetBody(rsp.Body, "application/json")
+	responseBody, err := openapi.SetBody(rsp.Body, contentTypeJson)
 	if err != nil {
 		logger.UecmLog.Errorln(err)
 		problemDetails := utils.ProblemDetailsSystemFailure(err.Error())
 		c.JSON(http.StatusInternalServerError, problemDetails)
 	} else {
-		c.Data(rsp.Status, "application/json", responseBody.Bytes())
+		c.Data(rsp.Status, contentTypeJson, responseBody.Bytes())
 	}
 }

--- a/uecontextmanagement/api_amf_registration_for_non3_gpp_access.go
+++ b/uecontextmanagement/api_amf_registration_for_non3_gpp_access.go
@@ -31,8 +31,6 @@ import (
 	"github.com/omec-project/util/httpwrapper"
 )
 
-const contentTypeJson = "application/json"
-
 // Put /:ueId/registrations/amf-non-3gpp-access
 // register as AMF for non-3GPP access
 func HTTPNon3GppRegistration(c *gin.Context) {

--- a/uecontextmanagement/api_parameter_update_in_the_amf_registration_for3_gpp_access.go
+++ b/uecontextmanagement/api_parameter_update_in_the_amf_registration_for3_gpp_access.go
@@ -41,7 +41,7 @@ func HTTPUpdate3GppRegistration(c *gin.Context) {
 	}
 
 	// step 2: convert requestBody to openapi models
-	err = openapi.Decode(&amf3GppAccessRegistrationModification, requestBody, "application/json")
+	err = openapi.Decode(&amf3GppAccessRegistrationModification, requestBody, contentTypeJson)
 	if err != nil {
 		problemDetail := "[Request Body] " + err.Error()
 		rsp := utils.ProblemDetailsMalformedRequestSyntax(problemDetail)
@@ -59,12 +59,12 @@ func HTTPUpdate3GppRegistration(c *gin.Context) {
 		return
 	}
 
-	responseBody, err := openapi.SetBody(rsp.Body, "application/json")
+	responseBody, err := openapi.SetBody(rsp.Body, contentTypeJson)
 	if err != nil {
 		logger.UecmLog.Errorln(err)
 		problemDetails := utils.ProblemDetailsSystemFailure(err.Error())
 		c.JSON(http.StatusInternalServerError, problemDetails)
 	} else {
-		c.Data(rsp.Status, "application/json", responseBody.Bytes())
+		c.Data(rsp.Status, contentTypeJson, responseBody.Bytes())
 	}
 }

--- a/uecontextmanagement/api_parameter_update_in_the_amf_registration_for_non3_gpp_access.go
+++ b/uecontextmanagement/api_parameter_update_in_the_amf_registration_for_non3_gpp_access.go
@@ -46,7 +46,7 @@ func HTTPUpdateNon3GppRegistration(c *gin.Context) {
 	}
 
 	// step 2: convert requestBody to openapi models
-	err = openapi.Decode(&amfNon3GppAccessRegistrationModification, requestBody, "application/json")
+	err = openapi.Decode(&amfNon3GppAccessRegistrationModification, requestBody, contentTypeJson)
 	if err != nil {
 		problemDetail := "[Request Body] " + err.Error()
 		rsp := utils.ProblemDetailsMalformedRequestSyntax(problemDetail)
@@ -64,12 +64,12 @@ func HTTPUpdateNon3GppRegistration(c *gin.Context) {
 		return
 	}
 
-	responseBody, err := openapi.SetBody(rsp.Body, "application/json")
+	responseBody, err := openapi.SetBody(rsp.Body, contentTypeJson)
 	if err != nil {
 		logger.UecmLog.Errorln(err)
 		problemDetails := utils.ProblemDetailsSystemFailure(err.Error())
 		c.JSON(http.StatusInternalServerError, problemDetails)
 	} else {
-		c.Data(rsp.Status, "application/json", responseBody.Bytes())
+		c.Data(rsp.Status, contentTypeJson, responseBody.Bytes())
 	}
 }

--- a/uecontextmanagement/api_smf_registration.go
+++ b/uecontextmanagement/api_smf_registration.go
@@ -55,7 +55,7 @@ func HTTPRegistration(c *gin.Context) {
 	}
 
 	// step 2: convert requestBody to openapi models
-	err = openapi.Decode(&smfRegistration, requestBody, "application/json")
+	err = openapi.Decode(&smfRegistration, requestBody, contentTypeJson)
 	if err != nil {
 		problemDetail := "[Request Body] " + err.Error()
 		rsp := utils.ProblemDetailsMalformedRequestSyntax(problemDetail)
@@ -72,12 +72,12 @@ func HTTPRegistration(c *gin.Context) {
 	for key, val := range rsp.Header { // header response is optional
 		c.Header(key, val[0])
 	}
-	responseBody, err := openapi.SetBody(rsp.Body, "application/json")
+	responseBody, err := openapi.SetBody(rsp.Body, contentTypeJson)
 	if err != nil {
 		logger.UecmLog.Errorln(err)
 		problemDetails := utils.ProblemDetailsSystemFailure(err.Error())
 		c.JSON(http.StatusInternalServerError, problemDetails)
 	} else {
-		c.Data(rsp.Status, "application/json", responseBody.Bytes())
+		c.Data(rsp.Status, contentTypeJson, responseBody.Bytes())
 	}
 }

--- a/uecontextmanagement/routers.go
+++ b/uecontextmanagement/routers.go
@@ -29,6 +29,13 @@ import (
 	utilLogger "github.com/omec-project/util/logger"
 )
 
+const (
+	pathAmf3gppAccess     = "/:ueId/registrations/amf-3gpp-access"
+	pathAmfNon3gppAccess  = "/:ueId/registrations/amf-non-3gpp-access"
+	pathSmsf3gppAccess    = "/:ueId/registrations/smsf-3gpp-access"
+	pathSmsfNon3gppAccess = "/:ueId/registrations/smsf-non-3gpp-access"
+)
+
 // Route is the information for every URI.
 type Route struct {
 	// Name is the name of this Route.
@@ -137,25 +144,25 @@ func getRoutes() []Route {
 		{
 			"Get3GppRegistration",
 			http.MethodGet,
-			"/:ueId/registrations/amf-3gpp-access",
+			pathAmf3gppAccess,
 			HTTPGet3GppRegistration,
 		},
 		{
 			"GetNon3GppRegistration",
 			http.MethodGet,
-			"/:ueId/registrations/amf-non-3gpp-access",
+			pathAmfNon3gppAccess,
 			HTTPGetNon3GppRegistration,
 		},
 		{
 			"Call3GppRegistration",
 			http.MethodPut,
-			"/:ueId/registrations/amf-3gpp-access",
+			pathAmf3gppAccess,
 			HTTPCall3GppRegistration,
 		},
 		{
 			"Non3GppRegistration",
 			http.MethodPut,
-			"/:ueId/registrations/amf-non-3gpp-access",
+			pathAmfNon3gppAccess,
 			HTTPNon3GppRegistration,
 		},
 		{
@@ -203,13 +210,13 @@ func getRoutes() []Route {
 		{
 			"Update3GppRegistration",
 			http.MethodPatch,
-			"/:ueId/registrations/amf-3gpp-access",
+			pathAmf3gppAccess,
 			HTTPUpdate3GppRegistration,
 		},
 		{
 			"UpdateNon3GppRegistration",
 			http.MethodPatch,
-			"/:ueId/registrations/amf-non-3gpp-access",
+			pathAmfNon3gppAccess,
 			HTTPUpdateNon3GppRegistration,
 		},
 		{
@@ -227,13 +234,13 @@ func getRoutes() []Route {
 		{
 			"UpdateSmsf3GppRegistration",
 			http.MethodPatch,
-			"/:ueId/registrations/smsf-3gpp-access",
+			pathSmsf3gppAccess,
 			HTTPUpdateSmsf3GppRegistration,
 		},
 		{
 			"UpdateSmsfNon3GppRegistration",
 			http.MethodPatch,
-			"/:ueId/registrations/smsf-non-3gpp-access",
+			pathSmsfNon3gppAccess,
 			HTTPUpdateSmsfNon3GppRegistration,
 		},
 		{
@@ -269,37 +276,37 @@ func getRoutes() []Route {
 		{
 			"Get3GppSmsfRegistration",
 			http.MethodGet,
-			"/:ueId/registrations/smsf-3gpp-access",
+			pathSmsf3gppAccess,
 			HTTPGet3GppSmsfRegistration,
 		},
 		{
 			"Call3GppSmsfDeregistration",
 			http.MethodDelete,
-			"/:ueId/registrations/smsf-3gpp-access",
+			pathSmsf3gppAccess,
 			HTTPCall3GppSmsfDeregistration,
 		},
 		{
 			"Non3GppSmsfDeregistration",
 			http.MethodDelete,
-			"/:ueId/registrations/smsf-non-3gpp-access",
+			pathSmsfNon3gppAccess,
 			HTTPNon3GppSmsfDeregistration,
 		},
 		{
 			"GetNon3GppSmsfRegistration",
 			http.MethodGet,
-			"/:ueId/registrations/smsf-non-3gpp-access",
+			pathSmsfNon3gppAccess,
 			HTTPGetNon3GppSmsfRegistration,
 		},
 		{
 			"Call3GppSmsfRegistration",
 			http.MethodPut,
-			"/:ueId/registrations/smsf-3gpp-access",
+			pathSmsf3gppAccess,
 			HTTPCall3GppSmsfRegistration,
 		},
 		{
 			"Non3GppSmsfRegistration",
 			http.MethodPut,
-			"/:ueId/registrations/smsf-non-3gpp-access",
+			pathSmsfNon3gppAccess,
 			HTTPNon3GppSmsfRegistration,
 		},
 		{

--- a/uecontextmanagement/routers.go
+++ b/uecontextmanagement/routers.go
@@ -34,6 +34,7 @@ const (
 	pathAmfNon3gppAccess  = "/:ueId/registrations/amf-non-3gpp-access"
 	pathSmsf3gppAccess    = "/:ueId/registrations/smsf-3gpp-access"
 	pathSmsfNon3gppAccess = "/:ueId/registrations/smsf-non-3gpp-access"
+	contentTypeJson       = "application/json"
 )
 
 // Route is the information for every URI.


### PR DESCRIPTION
**Description**

This PR refactors the uecontextmanagement package to address code quality issues by replacing duplicated string literals with constants across several files. Hardcoded, duplicate strings increase maintenance overhead and the likelihood of introducing typographical errors during future updates.

**Scope of Changes**

Constants were introduced to replace duplicated strings in:

- uecontextmanagement/api_amf_registration_for3_gpp_access.go
- uecontextmanagement/api_amf_registration_for_non3_gpp_access.go
- uecontextmanagement/api_parameter_update_in_the_amf_registration_for3_gpp_access.go
- uecontextmanagement/api_parameter_update_in_the_amf_registration_for_non3_gpp_access.go
- uecontextmanagement/api_smf_registration.go
- uecontextmanagement/routers.go